### PR TITLE
Release v1.0.0-alpha.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
       - name: Build
         run: cargo build --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,7 +229,7 @@ jobs:
           ref: ${{ needs.release.outputs.tag }}
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install dependencies
         run: brew install librsvg create-dmg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Initial release
-- PDF generation from source code files
-- Configurable headers and footers
-- Cover page with table of contents
-- Syntax highlighting support
-- Directory scanning with glob patterns
-- macOS DMG installer
+- PDF generation from source code files with syntax highlighting
+- Configurable page headers and footers with variable substitution
+- Cover page with table of contents and clickable hyperlinks
+- Directory scanning with glob patterns and file filtering
+- Flexible margin configuration (mm, cm, inches)
+- macOS DMG installer with app icon

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,7 +874,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "papercut"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src/config.rs
+++ b/src/config.rs
@@ -376,7 +376,7 @@ pub enum FontFamily {
     DejaVu,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct MetadataConfig {
     #[serde(default)]
     pub title: String,
@@ -386,17 +386,6 @@ pub struct MetadataConfig {
     pub subject: String,
     #[serde(default)]
     pub keywords: Vec<String>,
-}
-
-impl Default for MetadataConfig {
-    fn default() -> Self {
-        Self {
-            title: String::new(),
-            author: String::new(),
-            subject: String::new(),
-            keywords: Vec::new(),
-        }
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/src/pdf/cover_page.rs
+++ b/src/pdf/cover_page.rs
@@ -183,6 +183,7 @@ pub struct TocLink {
 ///
 /// Parameters:
 /// - `file_pages`: Pre-calculated page indices for each file (for hyperlinks)
+#[allow(clippy::too_many_arguments)]
 pub fn render_toc_page(
     font_manager: &mut FontManager,
     config: &Config,

--- a/src/pdf/generator.rs
+++ b/src/pdf/generator.rs
@@ -130,12 +130,12 @@ fn should_overwrite_file(path: &Path, force: bool) -> Result<bool> {
     print!("File '{}' already exists. Overwrite? [y/N]: ", path.display());
     io::stdout()
         .flush()
-        .map_err(|e| PapercutError::Io(e))?;
+        .map_err(PapercutError::Io)?;
 
     let mut input = String::new();
     io::stdin()
         .read_line(&mut input)
-        .map_err(|e| PapercutError::Io(e))?;
+        .map_err(PapercutError::Io)?;
 
     Ok(input.trim().eq_ignore_ascii_case("y"))
 }
@@ -228,7 +228,7 @@ fn calculate_document_layout(config: &Config, ctx: &PdfContext) -> Result<Docume
                 current_page += 1; // First TOC page
                 let remaining = total_files - entries_first_page;
                 if entries_per_subsequent_page > 0 {
-                    current_page += (remaining + entries_per_subsequent_page - 1) / entries_per_subsequent_page;
+                    current_page += remaining.div_ceil(entries_per_subsequent_page);
                 }
             }
         }
@@ -1084,7 +1084,7 @@ fn generate_multiple_pdfs(config: Config, verbose: bool, force: bool, warning_ma
         let line_height = font_size * config.page.line_spacing;
         let lines_per_page = ((ctx.content_height) / line_height).floor() as usize;
         let total_pages = if lines_per_page > 0 {
-            let content_pages = (single_file_line_count + lines_per_page - 1) / lines_per_page;
+            let content_pages = single_file_line_count.div_ceil(lines_per_page);
             if config.cover_page.enabled { content_pages + 1 } else { content_pages.max(1) }
         } else {
             1

--- a/src/pdf/header_footer.rs
+++ b/src/pdf/header_footer.rs
@@ -22,6 +22,7 @@ pub struct HeaderFooterContext<'a> {
 /// Parameters:
 /// - margin_left, margin_top, content_width: default page margins
 /// - page_width: total page width (needed for margin override calculations)
+#[allow(clippy::too_many_arguments)]
 pub fn render_header(
     surface: &mut Surface,
     font: Arc<Font>,
@@ -163,6 +164,7 @@ pub fn render_header(
 }
 
 /// Render footer on the given surface
+#[allow(clippy::too_many_arguments)]
 pub fn render_footer(
     surface: &mut Surface,
     font: Arc<Font>,

--- a/src/pdf/themes.rs
+++ b/src/pdf/themes.rs
@@ -197,7 +197,7 @@ fn create_vscode_light_modern_theme() -> Theme {
     Theme {
         name: Some("VSCode Light Modern".to_string()),
         author: Some("Microsoft".to_string()),
-        settings: settings,
+        settings,
         scopes: items,
     }
 }


### PR DESCRIPTION
## Summary
First prerelease of Papercut v1.0.0

## Changes
- PDF generation from source code files with syntax highlighting
- Configurable page headers and footers with variable substitution
- Cover page with table of contents and clickable hyperlinks
- Directory scanning with glob patterns and file filtering
- Flexible margin configuration (mm, cm, inches)
- macOS DMG installer with app icon

## Test plan
- [x] Verify CI build passes
- [ ] Check DMG is attached to release after merge