### PR TITLE
Release v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       bump:
-        description: 'Version bump type'
+        description: 'Version bump type (use "promote" to release current prerelease as stable)'
         required: true
         type: choice
         options:
+          - promote
           - major
           - minor
           - patch
@@ -108,17 +109,25 @@ jobs:
           fi
 
           # Check version bump type (exactly one required)
+          PROMOTE=$(echo "$LABELS" | jq 'map(select(. == "promote")) | length')
           MAJOR=$(echo "$LABELS" | jq 'map(select(. == "major")) | length')
           MINOR=$(echo "$LABELS" | jq 'map(select(. == "minor")) | length')
           PATCH=$(echo "$LABELS" | jq 'map(select(. == "patch")) | length')
 
-          BUMP_COUNT=$((MAJOR + MINOR + PATCH))
+          BUMP_COUNT=$((PROMOTE + MAJOR + MINOR + PATCH))
           if [ "$BUMP_COUNT" -ne 1 ]; then
-            echo "::error::Exactly one of 'major', 'minor', or 'patch' label is required"
+            echo "::error::Exactly one of 'promote', 'major', 'minor', or 'patch' label is required"
             exit 1
           fi
 
-          if [ "$MAJOR" -eq 1 ]; then
+          if [ "$PROMOTE" -eq 1 ]; then
+            # Promote cannot be used with prerelease label
+            if [ "$IS_PRERELEASE" -gt 0 ]; then
+              echo "::error::Cannot use 'promote' with 'prerelease' label. Promote is for releasing a prerelease as stable."
+              exit 1
+            fi
+            echo "bump=promote" >> $GITHUB_OUTPUT
+          elif [ "$MAJOR" -eq 1 ]; then
             echo "bump=major" >> $GITHUB_OUTPUT
           elif [ "$MINOR" -eq 1 ]; then
             echo "bump=minor" >> $GITHUB_OUTPUT
@@ -159,9 +168,20 @@ jobs:
           MINOR=$(echo "$CURRENT" | cut -d. -f2)
           PATCH=$(echo "$CURRENT" | cut -d. -f3 | cut -d- -f1)
 
+          # Check if current version is a prerelease
+          IS_PRERELEASE_VERSION=$(echo "$CURRENT" | grep -c '-' || true)
+
           # Apply bump
           BUMP="${{ steps.labels.outputs.bump }}"
           case "$BUMP" in
+            promote)
+              # Promote prerelease to stable - no version bump, just strip prerelease suffix
+              if [ "$IS_PRERELEASE_VERSION" -eq 0 ]; then
+                echo "::error::Cannot use 'promote' on a non-prerelease version. Use major/minor/patch instead."
+                exit 1
+              fi
+              # Version numbers stay the same, prerelease suffix will not be added
+              ;;
             major)
               MAJOR=$((MAJOR + 1))
               MINOR=0
@@ -272,11 +292,76 @@ jobs:
       - name: Install dependencies
         run: brew install librsvg create-dmg
 
+      - name: Import Apple certificate
+        if: ${{ secrets.APPLE_CERTIFICATE_BASE64 != '' }}
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          # Create temporary keychain
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificate
+          echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > $RUNNER_TEMP/certificate.p12
+          security import $RUNNER_TEMP/certificate.p12 \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+
+          # Allow codesign to access keychain
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+
+          # Clean up certificate file
+          rm $RUNNER_TEMP/certificate.p12
+
+          # Find and export signing identity
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep "Developer ID Application" | head -1 | awk -F'"' '{print $2}')
+          if [ -n "$IDENTITY" ]; then
+            echo "APPLE_SIGNING_IDENTITY=$IDENTITY" >> $GITHUB_ENV
+            echo "✓ Found signing identity: $IDENTITY"
+          else
+            echo "⚠️ No Developer ID Application certificate found"
+          fi
+
       - name: Build and package
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
         run: |
           cd packaging/macos
           ./build-macos.sh
           ./create-dmg.sh
+
+      - name: Notarize DMG
+        if: ${{ env.APPLE_SIGNING_IDENTITY != '' && secrets.APPLE_ID != '' }}
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          DMG_FILE=$(ls dist/*.dmg | head -1)
+
+          echo "📤 Submitting for notarization..."
+          xcrun notarytool submit "$DMG_FILE" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --wait
+
+          echo "📎 Stapling notarization ticket..."
+          xcrun stapler staple "$DMG_FILE"
+
+          echo "✓ Notarization complete"
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
 
       - name: Upload DMG to release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,25 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+      prerelease:
+        description: 'Prerelease type (leave empty for stable release)'
+        required: false
+        type: choice
+        options:
+          - ''
+          - alpha
+          - beta
+          - rc
 
 permissions:
   contents: write
@@ -11,7 +30,11 @@ permissions:
 jobs:
   release:
     name: Create Release
-    if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'prerelease'))
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       (contains(github.event.pull_request.labels.*.name, 'release') ||
+        contains(github.event.pull_request.labels.*.name, 'prerelease')))
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.new_version }}
@@ -53,6 +76,19 @@ jobs:
       - name: Extract and validate labels
         id: labels
         run: |
+          # Handle workflow_dispatch inputs
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "bump=${{ inputs.bump }}" >> $GITHUB_OUTPUT
+            if [ -n "${{ inputs.prerelease }}" ]; then
+              echo "prerelease=true" >> $GITHUB_OUTPUT
+              echo "pretype=${{ inputs.prerelease }}" >> $GITHUB_OUTPUT
+            else
+              echo "prerelease=false" >> $GITHUB_OUTPUT
+            fi
+            exit 0
+          fi
+
+          # Handle PR labels
           LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
           echo "Labels: $LABELS"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     types: [closed]
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Create Release
@@ -20,7 +23,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup GPG for signing
         run: |

--- a/.papercut.yaml
+++ b/.papercut.yaml
@@ -39,7 +39,7 @@ cover_page:
     enabled: true
     text: |
       Distribution A: This work has been cleared for public release,
-      distribution unlimited, case number: AFRL-2025-XXXX. The views expressed
+      distribution unlimited, case number: AFRL-2026-0405. The views expressed
       are those of the authors and do not reflect the official guidance or
       position of the United States Government, the Department of Defense or of
       the United States Air Force.

--- a/packaging/macos/build-macos.sh
+++ b/packaging/macos/build-macos.sh
@@ -1,4 +1,33 @@
 #!/bin/bash
+#
+# Papercut - Source code to PDF converter
+# Copyright (C) 2026 Papercut Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Distribution A: This work has been cleared for public release,
+# distribution unlimited, case number: AFRL-2026-0405. The views expressed
+# are those of the authors and do not reflect the official guidance or
+# position of the United States Government, the Department of Defense or of
+# the United States Air Force.
+#
+# Statement from DoD: The Appearance of external hyperlinks does not
+# constitute endorsement by the United States Department of Defense (DoD) of
+# the linked websites, of the information, products, or services contained
+# therein. The DoD does not exercise any editorial, security, or other
+# control over the information you may find at these locations.
+
 set -e
 
 # Build macOS application bundle and DMG installer for Papercut
@@ -88,6 +117,20 @@ sed "s/{{VERSION}}/$VERSION/g" "$PACKAGING_DIR/Info.plist.template" > "$APP_BUND
 echo "✓ Info.plist created"
 echo ""
 
+# Sign the app bundle
+if [ -n "$APPLE_SIGNING_IDENTITY" ]; then
+    echo "🔏 Signing app bundle with Developer ID..."
+    codesign --force --options=runtime --deep \
+        --sign "$APPLE_SIGNING_IDENTITY" \
+        --timestamp \
+        "$APP_BUNDLE"
+    echo "✓ App bundle signed with Developer ID"
+else
+    echo "🔏 Signing app bundle (ad-hoc)..."
+    codesign --force --deep --sign - "$APP_BUNDLE"
+    echo "✓ App bundle signed (ad-hoc)"
+fi
+echo ""
 
 echo "========================================"
 echo "✅ Build completed successfully!"

--- a/packaging/macos/create-dmg.sh
+++ b/packaging/macos/create-dmg.sh
@@ -1,4 +1,33 @@
 #!/bin/bash
+#
+# Papercut - Source code to PDF converter
+# Copyright (C) 2026 Papercut Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Distribution A: This work has been cleared for public release,
+# distribution unlimited, case number: AFRL-2026-0405. The views expressed
+# are those of the authors and do not reflect the official guidance or
+# position of the United States Government, the Department of Defense or of
+# the United States Air Force.
+#
+# Statement from DoD: The Appearance of external hyperlinks does not
+# constitute endorsement by the United States Department of Defense (DoD) of
+# the linked websites, of the information, products, or services contained
+# therein. The DoD does not exercise any editorial, security, or other
+# control over the information you may find at these locations.
+
 set -e
 
 # Create DMG installer for Papercut
@@ -93,8 +122,19 @@ rm -rf "$STAGING_DIR"
 
 if [ -f "$DIST_DIR/$DMG_NAME" ]; then
     echo ""
+    echo "✅ DMG created: $DIST_DIR/$DMG_NAME"
+
+    # Sign the DMG if signing identity is available
+    if [ -n "$APPLE_SIGNING_IDENTITY" ]; then
+        echo ""
+        echo "🔏 Signing DMG..."
+        codesign --force --sign "$APPLE_SIGNING_IDENTITY" --timestamp "$DIST_DIR/$DMG_NAME"
+        echo "✓ DMG signed"
+    fi
+
+    echo ""
     echo "========================================"
-    echo "✅ DMG created successfully!"
+    echo "✅ DMG packaging completed!"
     echo "========================================"
     echo ""
     echo "Output: $DIST_DIR/$DMG_NAME"
@@ -105,11 +145,6 @@ if [ -f "$DIST_DIR/$DMG_NAME" ]; then
     echo ""
     echo "To test the DMG:"
     echo "  open '$DIST_DIR/$DMG_NAME'"
-    echo ""
-    echo "To distribute:"
-    echo "  1. Test installation on a clean macOS system"
-    echo "  2. (Optional) Code sign and notarize for distribution"
-    echo "  3. Upload to your releases page"
     echo ""
 else
     echo "❌ Error: DMG creation failed!"

--- a/packaging/macos/scripts/generate-icons.sh
+++ b/packaging/macos/scripts/generate-icons.sh
@@ -1,4 +1,33 @@
 #!/bin/bash
+#
+# Papercut - Source code to PDF converter
+# Copyright (C) 2026 Papercut Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Distribution A: This work has been cleared for public release,
+# distribution unlimited, case number: AFRL-2026-0405. The views expressed
+# are those of the authors and do not reflect the official guidance or
+# position of the United States Government, the Department of Defense or of
+# the United States Air Force.
+#
+# Statement from DoD: The Appearance of external hyperlinks does not
+# constitute endorsement by the United States Department of Defense (DoD) of
+# the linked websites, of the information, products, or services contained
+# therein. The DoD does not exercise any editorial, security, or other
+# control over the information you may find at these locations.
+
 set -e
 
 # Generate macOS app icon (.icns) from SVG logo

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,31 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2026 Papercut Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde::de::{self, Visitor};
 use std::fmt;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,31 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2026 Papercut Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/file_scanner.rs
+++ b/src/file_scanner.rs
@@ -1,3 +1,31 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2026 Papercut Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
 use crate::error::{PapercutError, Result};
 use crate::warnings::{WarningManager, WarningCategory};
 use glob::Pattern;

--- a/src/highlighting.rs
+++ b/src/highlighting.rs
@@ -1,3 +1,31 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2026 Papercut Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
 use std::path::{Path, PathBuf};
 use syntect::easy::HighlightLines;
 use syntect::highlighting::{ThemeSet, Style, Color, Theme};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,31 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2026 Papercut Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
 mod config;
 mod error;
 mod file_scanner;

--- a/src/pdf/colors.rs
+++ b/src/pdf/colors.rs
@@ -1,3 +1,31 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2026 Papercut Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
 use krilla::color::rgb;
 use krilla::paint::Paint;
 

--- a/src/pdf/cover_page.rs
+++ b/src/pdf/cover_page.rs
@@ -1,3 +1,31 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2026 Papercut Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
 use crate::config::Config;
 use crate::error::Result;
 use crate::pdf::fonts::FontManager;

--- a/src/pdf/fonts.rs
+++ b/src/pdf/fonts.rs
@@ -1,3 +1,31 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2026 Papercut Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
 use crate::error::{PapercutError, Result};
 use crate::warnings::{WarningManager, WarningCategory};
 use fontdb::{Database, Query, Source};

--- a/src/pdf/generator.rs
+++ b/src/pdf/generator.rs
@@ -1,3 +1,31 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2026 Papercut Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
 use crate::config::{Config, OutputMode};
 use crate::error::{PapercutError, Result};
 use crate::pdf::krilla_doc::PdfContext;

--- a/src/pdf/header_footer.rs
+++ b/src/pdf/header_footer.rs
@@ -1,3 +1,31 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2026 Papercut Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
 use crate::config::HeaderFooterConfig;
 use crate::error::Result;
 use krilla::geom::Point;

--- a/src/pdf/krilla_doc.rs
+++ b/src/pdf/krilla_doc.rs
@@ -1,3 +1,31 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2026 Papercut Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
 use crate::config::{Config, EffectiveMetadata, PageSize};
 use crate::error::{PapercutError, Result};
 use crate::pdf::fonts::FontManager;

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -1,3 +1,31 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2026 Papercut Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
 mod colors;
 mod cover_page;
 mod fonts;

--- a/src/pdf/themes.rs
+++ b/src/pdf/themes.rs
@@ -1,3 +1,31 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2026 Papercut Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
 use syntect::highlighting::{Theme, ThemeSet, ThemeSettings, Color, StyleModifier, ScopeSelectors};
 use std::str::FromStr;
 

--- a/src/warnings.rs
+++ b/src/warnings.rs
@@ -1,3 +1,31 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2026 Papercut Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
 use std::collections::HashSet;
 use std::io::Write;
 use std::sync::Mutex;


### PR DESCRIPTION
## Summary
- Add GPL-3.0 license headers with DoD distribution notice (AFRL-2026-0405) to all source files
- Fix release workflow to support promoting prereleases to stable versions

## Release
This PR will trigger the release of **v1.0.0** when merged, promoting the current `1.0.0-alpha.1` to stable.

## Changes
- Added GPL-3.0 license headers to 14 Rust source files and 3 shell scripts
- Added 'promote' bump option to release workflow for prerelease-to-stable releases

## Test plan
- [ ] Verify license headers are present in all source files
- [ ] Verify release workflow triggers correctly on merge
- [ ] Verify v1.0.0 tag and GitHub release are created