### PR TITLE
Add CMake syntax highlighting and custom syntax support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
   workflow_dispatch:
     inputs:
       bump:
@@ -31,11 +28,6 @@ permissions:
 jobs:
   release:
     name: Create Release
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true &&
-       (contains(github.event.pull_request.labels.*.name, 'release') ||
-        contains(github.event.pull_request.labels.*.name, 'prerelease')))
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.new_version }}
@@ -74,86 +66,15 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Extract and validate labels
+      - name: Parse release inputs
         id: labels
         run: |
-          # Handle workflow_dispatch inputs
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "bump=${{ inputs.bump }}" >> $GITHUB_OUTPUT
-            if [ -n "${{ inputs.prerelease }}" ]; then
-              echo "prerelease=true" >> $GITHUB_OUTPUT
-              echo "pretype=${{ inputs.prerelease }}" >> $GITHUB_OUTPUT
-            else
-              echo "prerelease=false" >> $GITHUB_OUTPUT
-            fi
-            exit 0
-          fi
-
-          # Handle PR labels
-          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
-          echo "Labels: $LABELS"
-
-          # Check release type
-          IS_RELEASE=$(echo "$LABELS" | jq 'map(select(. == "release")) | length')
-          IS_PRERELEASE=$(echo "$LABELS" | jq 'map(select(. == "prerelease")) | length')
-
-          if [ "$IS_RELEASE" -gt 0 ] && [ "$IS_PRERELEASE" -gt 0 ]; then
-            echo "::error::Cannot have both 'release' and 'prerelease' labels"
-            exit 1
-          fi
-
-          if [ "$IS_PRERELEASE" -gt 0 ]; then
+          echo "bump=${{ inputs.bump }}" >> $GITHUB_OUTPUT
+          if [ -n "${{ inputs.prerelease }}" ]; then
             echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "pretype=${{ inputs.prerelease }}" >> $GITHUB_OUTPUT
           else
             echo "prerelease=false" >> $GITHUB_OUTPUT
-          fi
-
-          # Check version bump type (exactly one required)
-          PROMOTE=$(echo "$LABELS" | jq 'map(select(. == "promote")) | length')
-          MAJOR=$(echo "$LABELS" | jq 'map(select(. == "major")) | length')
-          MINOR=$(echo "$LABELS" | jq 'map(select(. == "minor")) | length')
-          PATCH=$(echo "$LABELS" | jq 'map(select(. == "patch")) | length')
-
-          BUMP_COUNT=$((PROMOTE + MAJOR + MINOR + PATCH))
-          if [ "$BUMP_COUNT" -ne 1 ]; then
-            echo "::error::Exactly one of 'promote', 'major', 'minor', or 'patch' label is required"
-            exit 1
-          fi
-
-          if [ "$PROMOTE" -eq 1 ]; then
-            # Promote cannot be used with prerelease label
-            if [ "$IS_PRERELEASE" -gt 0 ]; then
-              echo "::error::Cannot use 'promote' with 'prerelease' label. Promote is for releasing a prerelease as stable."
-              exit 1
-            fi
-            echo "bump=promote" >> $GITHUB_OUTPUT
-          elif [ "$MAJOR" -eq 1 ]; then
-            echo "bump=major" >> $GITHUB_OUTPUT
-          elif [ "$MINOR" -eq 1 ]; then
-            echo "bump=minor" >> $GITHUB_OUTPUT
-          else
-            echo "bump=patch" >> $GITHUB_OUTPUT
-          fi
-
-          # Check prerelease type (required if prerelease)
-          if [ "$IS_PRERELEASE" -gt 0 ]; then
-            ALPHA=$(echo "$LABELS" | jq 'map(select(. == "alpha")) | length')
-            BETA=$(echo "$LABELS" | jq 'map(select(. == "beta")) | length')
-            RC=$(echo "$LABELS" | jq 'map(select(. == "rc")) | length')
-
-            PRE_COUNT=$((ALPHA + BETA + RC))
-            if [ "$PRE_COUNT" -ne 1 ]; then
-              echo "::error::Prerelease requires exactly one of 'alpha', 'beta', or 'rc' label"
-              exit 1
-            fi
-
-            if [ "$ALPHA" -eq 1 ]; then
-              echo "pretype=alpha" >> $GITHUB_OUTPUT
-            elif [ "$BETA" -eq 1 ]; then
-              echo "pretype=beta" >> $GITHUB_OUTPUT
-            else
-              echo "pretype=rc" >> $GITHUB_OUTPUT
-            fi
           fi
 
       - name: Calculate new version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,7 +874,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "papercut"
-version = "0.0.0"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/assets/syntaxes/CMake.sublime-syntax
+++ b/assets/syntaxes/CMake.sublime-syntax
@@ -1,0 +1,630 @@
+%YAML 1.2
+# CMake Syntax Definition
+# Based on https://github.com/zyxar/Sublime-CMakeLists (MIT License)
+# Modified to be self-contained for Papercut
+# https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html
+---
+name: CMake
+file_extensions:
+  - cmake
+  - CMakeLists.txt
+first_line_match: (?i)^\s*cmake_minimum_required\s*\(
+scope: source.cmake
+
+variables:
+  unquoted_argument_element: "[^ \t()#\"\\']"
+  unquoted_argument: "{{unquoted_argument_element}}+"
+  identifier: \b[[:alpha:]_][[:alnum:]_]*\b
+  generic_named_parameter: \b@?[A-Z_][A-Z0-9_]*(?=[^\w\-<>=\$])
+
+contexts:
+  prototype:
+    - include: comment-block
+    - include: comment-line
+    - include: variable-substitution
+    - include: generator-expression
+
+  main:
+    - include: builtin-commands
+    - include: if
+    - include: foreach
+    - include: while
+    - include: set
+    - include: function
+    - include: macro
+    - include: include
+    - include: illegal-command
+    - include: generic-command
+
+  builtin-commands:
+    - match: (?i)\b(cmake_minimum_required|cmake_policy|project|add_executable|add_library|add_subdirectory|add_custom_command|add_custom_target|add_dependencies|add_test|target_link_libraries|target_include_directories|target_compile_definitions|target_compile_options|target_sources|find_package|find_library|find_path|find_file|find_program|include_directories|link_directories|link_libraries|install|configure_file|execute_process|file|string|list|math|message|option|return|get_property|set_property|get_target_property|set_target_properties|get_directory_property|set_directory_properties|get_source_file_property|set_source_files_properties|get_cmake_property|mark_as_advanced|separate_arguments|unset|cmake_parse_arguments|export|enable_testing|enable_language|get_filename_component|aux_source_directory|try_compile|try_run|variable_watch|cmake_host_system_information|load_cache|remove|remove_definitions|add_compile_definitions|add_compile_options|add_link_options|target_link_options|target_link_directories|target_precompile_headers|cmake_path|block|endblock)\b
+      scope: support.function.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: generic-args
+        - include: args-illegal-boilerplate
+
+  illegal-command:
+    - match: (?i)\bendif\b
+      scope: invalid.illegal.stray.endif.cmake
+    - match: (?i)\belse\b
+      scope: invalid.illegal.stray.else.cmake
+    - match: (?i)\belseif\b
+      scope: invalid.illegal.stray.elseif.cmake
+    - match: (?i)\bendforeach\b
+      scope: invalid.illegal.stray.endforeach.cmake
+    - match: (?i)\bendwhile\b
+      scope: invalid.illegal.stray.endwhile.cmake
+    - match: (?i)\bbreak\b
+      scope: invalid.illegal.stray.break.cmake
+    - match: (?i)\bendfunction\b
+      scope: invalid.illegal.stray.endfunction.cmake
+    - match: (?i)\bendmacro\b
+      scope: invalid.illegal.stray.endmacro.cmake
+
+  args-illegal-boilerplate:
+    - match: \s+
+    - match: \n
+    - match: .+
+      scope: invalid.illegal.expected-opening-brace.cmake
+      pop: true
+
+  include:
+    - match: (?i)\binclude\b
+      scope: keyword.control.import.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: include-args
+        - include: args-illegal-boilerplate
+
+  include-args:
+    - meta_scope: meta.function-call.arguments.cmake
+    - match: \bOPTIONAL\b
+      scope: variable.parameter.include.OPTIONAL.cmake
+    - match: \bNO_POLICY_SCOPE\b
+      scope: variable.parameter.include.NO_POLICY_SCOPE.cmake
+    - match: \bRESULT_VARIABLE\b
+      scope: variable.parameter.include.RESULT_VARIABLE.cmake
+      push:
+        - match: \b{{identifier}}\b
+          scope: variable.other.readwrite.cmake
+          pop: true
+        - match: \s+
+        - match: \n
+        - match: ''
+          pop: true
+    - include: args-common
+
+  function:
+    - match: (?i)\bfunction\b
+      scope: support.function.function.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [function-body, function-args-first]
+        - include: args-illegal-boilerplate
+
+  function-args-first:
+    - meta_scope: meta.function-call.arguments.cmake
+    - match: '{{identifier}}'
+      scope: entity.name.function.cmake
+      set: function-args-rest
+    - include: variable-substitution
+    - match: \s+
+    - match: ''
+      set: function-args-rest
+
+  function-args-rest:
+    - meta_scope: meta.function-call.arguments.cmake
+    - include: args-common
+    - match: '{{identifier}}'
+      scope: variable.parameter.cmake
+
+  function-body:
+    - meta_scope: meta.group.function.cmake
+    - include: endfunction
+    - include: main
+
+  endfunction:
+    - match: (?i)\bendfunction\b
+      scope: support.function.endfunction.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: generic-args
+        - include: args-illegal-boilerplate
+
+  macro:
+    - match: (?i)\bmacro\b
+      scope: support.function.macro.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [macro-body, macro-args-first]
+        - include: args-illegal-boilerplate
+
+  macro-args-first:
+    - meta_scope: meta.function-call.arguments.cmake
+    - match: '{{identifier}}'
+      scope: entity.name.function.cmake
+      set: macro-args-rest
+    - include: variable-substitution
+    - match: \s+
+    - match: ''
+      set: macro-args-rest
+
+  macro-args-rest:
+    - meta_scope: meta.function-call.arguments.cmake
+    - include: args-common
+    - match: '{{identifier}}'
+      scope: variable.parameter.cmake
+
+  macro-body:
+    - meta_scope: meta.group.function.cmake
+    - include: endmacro
+    - include: main
+
+  endmacro:
+    - match: (?i)\bendmacro\b
+      scope: support.function.endmacro.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: generic-args
+        - include: args-illegal-boilerplate
+
+  if:
+    - match: (?i)\bif\b
+      scope: keyword.control.if.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [if-body, if-args]
+        - include: args-illegal-boilerplate
+
+  if-body:
+    - meta_scope: meta.group.if.cmake
+    - include: else
+    - include: elseif
+    - include: endif
+    - include: break
+    - include: main
+
+  if-args-inline:
+    - match: \(
+      scope: punctuation.section.parens.begin.cmake
+      push: if-args
+    - match: \bDEFINED\b
+      scope: variable.parameter.if.DEFINED.cmake
+    - match: \bSTREQUAL\b
+      scope: variable.parameter.if.STREQUAL.cmake
+    - match: \bNOT\b
+      scope: keyword.operator.logical.NOT.cmake
+    - match: \bAND\b
+      scope: keyword.operator.logical.AND.cmake
+    - match: \bOR\b
+      scope: keyword.operator.logical.OR.cmake
+    - match: \bCOMMAND\b
+      scope: variable.parameter.if.COMMAND.cmake
+    - match: \bPOLICY\b
+      scope: variable.parameter.if.POLICY.cmake
+    - match: \bTARGET\b
+      scope: variable.parameter.if.TARGET.cmake
+    - match: \bTEST\b
+      scope: variable.parameter.if.TEST.cmake
+    - match: \bEXISTS\b
+      scope: variable.parameter.if.EXISTS.cmake
+    - match: \bIS_NEWER_THAN\b
+      scope: variable.parameter.if.IS_NEWER_THAN.cmake
+    - match: \bIS_DIRECTORY\b
+      scope: variable.parameter.if.IS_DIRECTORY.cmake
+    - match: \bIS_SYMLINK\b
+      scope: variable.parameter.if.IS_SYMLINK.cmake
+    - match: \bIS_ABSOLUTE\b
+      scope: variable.parameter.if.IS_ABSOLUTE.cmake
+    - match: \b(VERSION_|STR)?LESS\b
+      scope: variable.parameter.if.LESS.cmake
+    - match: \b(VERSION_|STR)?GREATER\b
+      scope: variable.parameter.if.GREATER.cmake
+    - match: \b(VERSION_|STR)?EQUAL\b
+      scope: variable.parameter.if.EQUAL.cmake
+    - match: \b(VERSION_|STR)?LESS_EQUAL\b
+      scope: variable.parameter.if.LESS_EQUAL.cmake
+    - match: \b(VERSION_|STR)?GREATER_EQUAL\b
+      scope: variable.parameter.if.GREATER_EQUAL.cmake
+    - match: \bMATCHES\b
+      scope: variable.parameter.if.MATCHES.cmake
+
+  if-args:
+    - meta_scope: meta.function-call.arguments.cmake
+    - include: if-args-inline
+    - include: args-common
+
+  elseif:
+    - match: (?i)\belseif\b
+      scope: keyword.control.elseif.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [elseif-body, if-args]
+        - include: args-illegal-boilerplate
+
+  elseif-body:
+    - meta_scope: meta.group.elseif.cmake
+    - include: elseif
+    - include: else
+    - include: endif
+    - include: break
+    - include: main
+
+  else:
+    - match: (?i)\b\belse\b
+      scope: keyword.control.else.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [else-body, if-args]
+        - include: args-illegal-boilerplate
+
+  else-body:
+    - meta_scope: meta.group.else.cmake
+    - include: endif
+    - include: break
+    - include: main
+    - match: (?i)\belse\b
+      scope: invalid.illegal.stray.else.cmake
+    - match: (?i)\belseif\b
+      scope: invalid.illegal.stray.elseif.cmake
+
+  endif:
+    - match: (?i)\bendif\b
+      scope: keyword.control.endif.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: if-args
+        - include: args-illegal-boilerplate
+
+  foreach:
+    - match: (?i)\bforeach\b
+      scope: keyword.control.foreach.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [foreach-body, foreach-args]
+        - include: args-illegal-boilerplate
+
+  foreach-args:
+    - meta_scope: meta.function-call.arguments.cmake
+    - match: \bIN\b
+      scope: variable.parameter.foreach.IN.cmake
+    - match: \bLISTS\b
+      scope: variable.parameter.foreach.LISTS.cmake
+    - match: \bITEMS\b
+      scope: variable.parameter.foreach.ITEMS.cmake
+    - match: \bRANGE\b
+      scope: variable.parameter.foreach.RANGE.cmake
+    - include: args-common
+
+  foreach-body:
+    - meta_scope: meta.group.foreach.cmake
+    - include: break
+    - include: continue
+    - include: endforeach
+    - include: main
+
+  endforeach:
+    - match: (?i)\bendforeach\b
+      scope: keyword.control.endforeach.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: foreach-args
+        - include: args-illegal-boilerplate
+
+  while:
+    - match: (?i)\bwhile\b
+      scope: keyword.control.while.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [while-body, if-args]
+        - include: args-illegal-boilerplate
+
+  while-body:
+    - meta_scope: meta.group.while.cmake
+    - include: break
+    - include: continue
+    - include: endwhile
+    - include: main
+
+  endwhile:
+    - match: (?i)\bendwhile\b
+      scope: keyword.control.endwhile.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: if-args
+        - include: args-illegal-boilerplate
+
+  break:
+    - match: (?i)\bbreak\b
+      scope: keyword.control.break.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: break-args
+        - include: args-illegal-boilerplate
+
+  break-args:
+    - meta_scope: meta.function-call.arguments.cmake
+    - include: args-common
+
+  continue:
+    - match: (?i)\bcontinue\b
+      scope: keyword.control.continue.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: continue-args
+        - include: args-illegal-boilerplate
+
+  continue-args:
+    - meta_scope: meta.function-call.arguments.cmake
+    - include: args-common
+
+  set:
+    - match: (?i)\bset\b
+      scope: support.function.set.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [set-args-rest, set-args-first]
+
+  set-args-first:
+    - match: '{{identifier}}'
+      scope: variable.other.readwrite.assignment.cmake
+      pop: true
+    - include: variable-substitution
+    - match: \s+
+    - match: ''
+      pop: true
+
+  set-args-rest:
+    - meta_scope: meta.function-call.arguments.cmake
+    - match: \bFORCE\b
+      scope: variable.parameter.foreach.FORCE.cmake
+    - match: \bPARENT_SCOPE\b
+      scope: variable.parameter.foreach.PARENT_SCOPE.cmake
+    - match: \bCACHE\b
+      scope: variable.parameter.foreach.CACHE.cmake
+      push:
+        - match: \s*(FILEPATH)
+          captures:
+            1: storage.type.FILEPATH.cmake
+          pop: true
+        - match: \s*(PATH)
+          captures:
+            1: storage.type.PATH.cmake
+          pop: true
+        - match: \s*(STRING)
+          captures:
+            1: storage.type.STRING.cmake
+          pop: true
+        - match: \s*(BOOL)
+          captures:
+            1: storage.type.BOOL.cmake
+          pop: true
+        - match: \s*(INTERNAL)
+          captures:
+            1: storage.type.INTERNAL.cmake
+          pop: true
+        - match: \s*([^\s]*)
+          captures:
+            1: invalid.illegal.expected-type.cmake
+          pop: true
+    - include: args-common
+
+  args-common:
+    - match: \)
+      scope: punctuation.section.parens.end.cmake
+      pop: true
+    - match: \(
+      scope: invalid.illegal.stray.parenthesis.cmake
+    - include: string
+
+  generic-command:
+    - match: \b{{identifier}}\b
+      scope: variable.function.generic.cmake
+      push:
+        - meta_scope: meta.function-call.generic.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: generic-args
+
+  generic-args:
+    - meta_scope: meta.function-call.arguments.generic.cmake
+    - match: \)
+      scope: punctuation.section.parens.end.cmake
+      pop: true
+    - include: if-args-inline
+    - match: (?={{generic_named_parameter}})
+      push: unquoted-argument-or-keyword
+    - include: string-unquoted
+    - include: string-quoted-double
+
+  unquoted-argument-or-keyword:
+    - meta_scope: variable.parameter.generic.cmake
+    - match: (?=\t| |\(|\)|\#|\"|\\)
+      pop: true
+
+  string:
+    - include: string-raw
+    - include: string-quoted-double
+    - include: string-unquoted
+
+  string-raw:
+    - match: \[(=*)\[
+      scope: punctuation.definition.string.begin.cmake
+      push:
+        - meta_include_prototype: false
+        - meta_scope: string.raw.cmake
+        - match: \]\1\]
+          scope: punctuation.definition.string.end.cmake
+          pop: true
+
+  string-quoted-double:
+    - match: '"'
+      scope: punctuation.definition.string.begin.cmake
+      push:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.double.cmake
+        - match: '"'
+          scope: punctuation.definition.string.end.cmake
+          pop: true
+        - include: escape-sequences
+        - include: highlight-semicolon
+        - include: variable-substitution
+        - include: generator-expression
+
+  string-unquoted:
+    - match: (?={{unquoted_argument}})
+      push:
+        - meta_include_prototype: false
+        - meta_scope: meta.string.unquoted.cmake
+        - include: variable-substitution
+        - include: generator-expression
+        - match: \\[; ()#"\\]
+          scope: constant.character.escape.cmake
+        - match: \\.
+          scope: invalid.illegal.character.escape.cmake
+        - match: (?=\t| |\(|\)|\#|\"|\\|\n)
+          pop: true
+        - match: (?=\s*$)
+          set:
+            - match: \s*$
+              pop: true
+        - match: (?=\s*#)
+          set: prototype
+        - include: highlight-semicolon
+
+  highlight-semicolon:
+    - match: ;
+      scope: punctuation.separator.cmake
+
+  escape-sequences:
+    - match: \\[()#" \\$@^trn;]
+      scope: constant.character.escape.cmake
+    - match: \\.
+      scope: invalid.illegal.character.escape.cmake
+
+  variable-substitution:
+    - match: (\$)(ENV)?(\{)
+      captures:
+        1: punctuation.definition.variable.substitution.cmake
+        2: keyword.operator.word.cmake
+        3: punctuation.section.braces.begin.cmake
+      push:
+        - meta_scope: meta.text-substitution.cmake
+        - match: \}
+          scope: punctuation.section.braces.end.cmake
+          pop: true
+        - match: '{{identifier}}'
+          scope: variable.other.readwrite.cmake
+        - include: prototype
+
+  generator-expression:
+    - match: (\$)(<)
+      captures:
+        1: punctuation.definition.variable.generator-expression.cmake
+        2: punctuation.section.block.begin.cmake
+      push:
+        - meta_scope: meta.generator-expression.cmake
+        - include: generator-expression-common
+        - match: ':'
+          scope: punctuation.separator.generator-expression.cmake
+          set:
+            - meta_content_scope: meta.generator-expression.cmake
+            - include: generator-expression-common
+            - include: variable-substitution
+            - include: generator-expression
+        - include: prototype
+
+  generator-expression-common:
+    - match: '>'
+      scope: punctuation.section.block.end.cmake
+      pop: true
+    - match: '{{identifier}}'
+      scope: variable.other.readwrite.cmake
+
+  comment-block:
+    - match: \#\[(=*)\[
+      scope: punctuation.definition.comment.begin.cmake
+      push:
+        - meta_scope: comment.block.cmake
+        - match: \]\1\]
+          scope: punctuation.definition.comment.end.cmake
+          pop: true
+
+  comment-line:
+    - match: \#
+      scope: punctuation.definition.comment.cmake
+      push:
+        - meta_scope: comment.line.cmake
+        - match: $
+          pop: true

--- a/src/config.rs
+++ b/src/config.rs
@@ -223,6 +223,10 @@ pub struct SyntaxHighlightingConfig {
     /// Theme name (e.g., "base16-ocean.dark", "InspiredGitHub")
     #[serde(default = "default_theme")]
     pub theme: String,
+    /// Custom syntax sources - can be directories or individual .sublime-syntax files
+    /// Directories are scanned for all .sublime-syntax files
+    #[serde(default)]
+    pub custom_syntaxes: Vec<PathBuf>,
 }
 
 impl Default for SyntaxHighlightingConfig {
@@ -230,6 +234,7 @@ impl Default for SyntaxHighlightingConfig {
         Self {
             enabled: true,
             theme: default_theme(),
+            custom_syntaxes: Vec::new(),
         }
     }
 }

--- a/src/highlighting.rs
+++ b/src/highlighting.rs
@@ -29,7 +29,7 @@
 use std::path::{Path, PathBuf};
 use syntect::easy::HighlightLines;
 use syntect::highlighting::{ThemeSet, Style, Color, Theme};
-use syntect::parsing::SyntaxSet;
+use syntect::parsing::{SyntaxSet, SyntaxSetBuilder, SyntaxDefinition};
 use syntect::util::LinesWithEndings;
 use crate::pdf::themes::ThemePreset;
 use crate::warnings::{WarningManager, WarningCategory};
@@ -45,6 +45,113 @@ pub struct StyledSegment {
     pub bold: bool,
     pub italic: bool,
     pub underline: bool,
+}
+
+/// Build SyntaxSet with defaults + embedded CMake + config syntaxes + convention dirs
+fn build_syntax_set(
+    config_syntaxes: &[PathBuf],
+    warning_manager: &WarningManager
+) -> SyntaxSet {
+    let mut builder = SyntaxSet::load_defaults_newlines().into_builder();
+
+    // 1. Add embedded CMake syntax
+    let cmake_syntax_yaml = include_str!("../assets/syntaxes/CMake.sublime-syntax");
+    match SyntaxDefinition::load_from_str(cmake_syntax_yaml, true, None) {
+        Ok(syntax) => builder.add(syntax),
+        Err(e) => warning_manager.warnf(
+            WarningCategory::Highlighting,
+            format!("Failed to load embedded CMake syntax: {}", e)
+        ),
+    }
+
+    // 2. Add syntaxes specified in config file (directories or files)
+    for path in config_syntaxes {
+        // Expand ~ to home directory
+        let expanded_path = expand_tilde(path);
+
+        if !expanded_path.exists() {
+            warning_manager.warnf(
+                WarningCategory::Highlighting,
+                format!("Custom syntax path not found: {}", path.display())
+            );
+            continue;
+        }
+
+        if expanded_path.is_dir() {
+            // Load all .sublime-syntax files from directory
+            if let Err(e) = builder.add_from_folder(&expanded_path, true) {
+                warning_manager.warnf(
+                    WarningCategory::Highlighting,
+                    format!("Failed to load syntaxes from '{}': {}", expanded_path.display(), e)
+                );
+            }
+        } else {
+            // Load individual file
+            load_syntax_file(&mut builder, &expanded_path, warning_manager);
+        }
+    }
+
+    // 3. Add syntaxes from convention directories (.papercut/syntaxes/)
+    for dir in get_convention_syntax_dirs() {
+        if let Err(e) = builder.add_from_folder(&dir, true) {
+            warning_manager.warnf(
+                WarningCategory::Highlighting,
+                format!("Failed to load syntaxes from '{}': {}", dir.display(), e)
+            );
+        }
+    }
+
+    builder.build()
+}
+
+/// Load a single syntax file
+fn load_syntax_file(builder: &mut SyntaxSetBuilder, path: &Path, warning_manager: &WarningManager) {
+    match fs::read_to_string(path) {
+        Ok(content) => {
+            match SyntaxDefinition::load_from_str(&content, true, None) {
+                Ok(syntax) => builder.add(syntax),
+                Err(e) => warning_manager.warnf(
+                    WarningCategory::Highlighting,
+                    format!("Failed to parse syntax '{}': {}", path.display(), e)
+                ),
+            }
+        }
+        Err(e) => warning_manager.warnf(
+            WarningCategory::Highlighting,
+            format!("Failed to read syntax file '{}': {}", path.display(), e)
+        ),
+    }
+}
+
+/// Expand ~ to home directory in path
+fn expand_tilde(path: &Path) -> PathBuf {
+    if let Some(path_str) = path.to_str() {
+        if path_str.starts_with("~/") {
+            if let Some(home) = dirs::home_dir() {
+                return home.join(&path_str[2..]);
+            }
+        }
+    }
+    path.to_path_buf()
+}
+
+/// Get convention syntax directories (project-level first, then user home)
+fn get_convention_syntax_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+
+    let project_dir = PathBuf::from("./.papercut/syntaxes");
+    if project_dir.exists() && project_dir.is_dir() {
+        dirs.push(project_dir);
+    }
+
+    if let Some(home) = dirs::home_dir() {
+        let home_dir = home.join(".papercut/syntaxes");
+        if home_dir.exists() && home_dir.is_dir() {
+            dirs.push(home_dir);
+        }
+    }
+
+    dirs
 }
 
 /// Try to load a custom theme from .papercut folders
@@ -106,9 +213,15 @@ fn load_custom_theme(theme_name: &str, warning_manager: &WarningManager) -> Opti
 }
 
 /// Highlight code and return styled segments for PDF rendering
-pub fn highlight_code_styled(code: &str, file_path: &Path, theme_name: &str, warning_manager: &WarningManager) -> Result<Vec<Vec<StyledSegment>>, String> {
-    // Load syntax set
-    let ss = SyntaxSet::load_defaults_newlines();
+pub fn highlight_code_styled(
+    code: &str,
+    file_path: &Path,
+    theme_name: &str,
+    custom_syntaxes: &[PathBuf],
+    warning_manager: &WarningManager
+) -> Result<Vec<Vec<StyledSegment>>, String> {
+    // Load syntax set with custom syntaxes
+    let ss = build_syntax_set(custom_syntaxes, warning_manager);
 
     // Get the syntax definition based on file extension
     let syntax = ss
@@ -189,6 +302,35 @@ pub fn list_themes() {
     println!("You can also place custom .tmTheme files in .papercut/themes/");
 }
 
+/// List all available syntax definitions
+pub fn list_syntaxes(config_syntaxes: &[PathBuf]) {
+    let warning_manager = WarningManager::new(true);
+    let ss = build_syntax_set(config_syntaxes, &warning_manager);
+
+    println!("Available Syntax Definitions:");
+    println!();
+
+    let mut syntaxes: Vec<_> = ss.syntaxes().iter().collect();
+    syntaxes.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+
+    for syntax in syntaxes {
+        let exts: Vec<_> = syntax.file_extensions.iter()
+            .map(|s| s.as_str())
+            .collect();
+        let exts_str = exts.join(", ");
+        if exts_str.is_empty() {
+            println!("  - {}", syntax.name);
+        } else {
+            println!("  - {} ({})", syntax.name, exts_str);
+        }
+    }
+
+    println!();
+    println!("Custom syntaxes can be added via:");
+    println!("  - config: syntax_highlighting.custom_syntaxes");
+    println!("  - directories: .papercut/syntaxes/ or ~/.papercut/syntaxes/");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -199,7 +341,7 @@ mod tests {
         let code = "fn main() {\n    println!(\"Hello, world!\");\n}\n";
         let path = PathBuf::from("test.rs");
         let warning_manager = WarningManager::new(false);
-        let result = highlight_code_styled(code, &path, "base16-ocean.dark", &warning_manager);
+        let result = highlight_code_styled(code, &path, "base16-ocean.dark", &[], &warning_manager);
 
         assert!(result.is_ok());
         let lines = result.unwrap();
@@ -214,8 +356,61 @@ mod tests {
         let code = "fn main() {}";
         let path = PathBuf::from("test.rs");
         let warning_manager = WarningManager::new(false);
-        let result = highlight_code_styled(code, &path, "nonexistent-theme", &warning_manager);
+        let result = highlight_code_styled(code, &path, "nonexistent-theme", &[], &warning_manager);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cmake_syntax_available() {
+        let warning_manager = WarningManager::new(false);
+        let ss = build_syntax_set(&[], &warning_manager);
+
+        // Check that CMake syntax is available
+        let cmake_syntax = ss.find_syntax_by_name("CMake");
+        assert!(cmake_syntax.is_some(), "CMake syntax should be available");
+
+        // Check that it matches CMakeLists.txt files
+        let cmake_path = PathBuf::from("CMakeLists.txt");
+        let syntax = ss.find_syntax_for_file(&cmake_path).ok().flatten();
+        assert!(syntax.is_some(), "Should find syntax for CMakeLists.txt");
+        assert_eq!(syntax.unwrap().name, "CMake");
+    }
+
+    #[test]
+    fn test_highlight_cmake_code() {
+        let code = r#"cmake_minimum_required(VERSION 3.10)
+project(MyProject)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(myapp main.cpp)
+"#;
+        let path = PathBuf::from("CMakeLists.txt");
+        let warning_manager = WarningManager::new(false);
+        let result = highlight_code_styled(code, &path, "base16-ocean.dark", &[], &warning_manager);
+
+        assert!(result.is_ok());
+        let lines = result.unwrap();
+        assert!(!lines.is_empty());
+        // Check that we got styled segments
+        let first_line_text: String = lines[0].iter().map(|s| s.text.as_str()).collect();
+        assert!(first_line_text.contains("cmake_minimum_required"));
+    }
+
+    #[test]
+    fn test_expand_tilde() {
+        // Test with a tilde path
+        let path = PathBuf::from("~/test/path");
+        let expanded = expand_tilde(&path);
+
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(expanded, home.join("test/path"));
+        }
+
+        // Test without tilde (should remain unchanged)
+        let path_no_tilde = PathBuf::from("/absolute/path");
+        let expanded_no_tilde = expand_tilde(&path_no_tilde);
+        assert_eq!(expanded_no_tilde, path_no_tilde);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,11 @@ struct Args {
     #[cfg(feature = "syntax-highlighting")]
     #[arg(long)]
     list_themes: bool,
+
+    /// List available syntax definitions (requires syntax-highlighting feature)
+    #[cfg(feature = "syntax-highlighting")]
+    #[arg(long)]
+    list_syntaxes: bool,
 }
 
 fn main() -> Result<()> {
@@ -80,6 +85,23 @@ fn main() -> Result<()> {
     #[cfg(feature = "syntax-highlighting")]
     if args.list_themes {
         highlighting::list_themes();
+        return Ok(());
+    }
+
+    #[cfg(feature = "syntax-highlighting")]
+    if args.list_syntaxes {
+        // Determine config file path for loading custom_syntaxes
+        let default_config = PathBuf::from(".papercut.yaml");
+        let config_path = args.config.as_ref().unwrap_or(&default_config);
+
+        let custom_syntaxes = if config_path.exists() {
+            Config::from_file(config_path)
+                .map(|c| c.syntax_highlighting.custom_syntaxes)
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        highlighting::list_syntaxes(&custom_syntaxes);
         return Ok(());
     }
 

--- a/src/pdf/generator.rs
+++ b/src/pdf/generator.rs
@@ -664,6 +664,7 @@ fn generate_single_pdf(config: Config, verbose: bool, force: bool, warning_manag
                 &content,
                 &file_entry.path,
                 &config.syntax_highlighting.theme,
+                &config.syntax_highlighting.custom_syntaxes,
                 &warning_manager
             ) {
                 Ok(result) => Some(result),


### PR DESCRIPTION
## Summary

- Add embedded CMake syntax definition for `CMakeLists.txt` and `.cmake` files
- Add `custom_syntaxes` config field for user-specified syntax files/directories
- Support convention directories (`.papercut/syntaxes/`, `~/.papercut/syntaxes/`)
- Add `--list-syntaxes` CLI flag to show available syntax definitions
- Refactor highlighting module to use `SyntaxSetBuilder` for extensibility
- Simplify release workflow to manual-only trigger

## Test plan

- [x] `cargo build --features syntax-highlighting` succeeds
- [x] `cargo test --features syntax-highlighting` passes (18 tests)
- [x] `--list-syntaxes` shows CMake in the list
- [x] Generate PDF with CMakeLists.txt to verify highlighting works

Closes #3