### PR TITLE
Add markdown report support with SVG vector graphics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +414,12 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
@@ -480,6 +492,15 @@ dependencies = [
  "windows",
  "windows-core 0.58.0",
  "yeslogic-fontconfig-sys",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -600,6 +621,12 @@ dependencies = [
 
 [[package]]
 name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
+name = "imagesize"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
@@ -662,17 +689,18 @@ dependencies = [
 
 [[package]]
 name = "krilla"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199be5f63da6e19b71051fd5276258a8e55449ac48e2e7492c68238f38ca9f3b"
+checksum = "a0ddfec86fec13d068075e14f22a7e217c281f3ed69ddcb427bf3f5d504fd674"
 dependencies = [
  "base64",
  "bumpalo",
  "flate2",
- "float-cmp",
+ "float-cmp 0.10.0",
  "gif",
  "image-webp",
- "imagesize",
+ "imagesize 0.14.0",
+ "indexmap",
  "once_cell",
  "pdf-writer",
  "png",
@@ -685,7 +713,33 @@ dependencies = [
  "tiny-skia-path",
  "xmp-writer",
  "yoke",
- "zune-jpeg",
+ "zune-jpeg 0.5.12",
+]
+
+[[package]]
+name = "krilla-svg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f485e1a850201a01dcd8d73e7cf09f2cd4c4cc85c2cd296359094d49336d8ef7"
+dependencies = [
+ "flate2",
+ "fontdb",
+ "krilla",
+ "png",
+ "resvg",
+ "tiny-skia",
+ "usvg",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
 ]
 
 [[package]]
@@ -874,7 +928,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "papercut"
-version = "1.0.0-alpha.1"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -885,11 +939,14 @@ dependencies = [
  "indicatif",
  "is-terminal",
  "krilla",
+ "krilla-svg",
  "parley",
+ "pulldown-cmark",
  "serde",
  "serde_yaml",
  "syntect",
  "thiserror 1.0.69",
+ "usvg",
  "walkdir",
 ]
 
@@ -918,6 +975,12 @@ dependencies = [
  "memchr",
  "ryu",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pkg-config"
@@ -971,6 +1034,25 @@ checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags 2.10.0",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quick-error"
@@ -1034,6 +1116,32 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg 0.4.21",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "roxmltree"
@@ -1155,6 +1263,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1313,9 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp 0.9.0",
+]
 
 [[package]]
 name = "strsim"
@@ -1209,10 +1329,20 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb6895a12ac5599bb6057362f00e8a3cf1daab4df33f553a55690a44e4fed8d0"
 dependencies = [
- "kurbo",
+ "kurbo 0.12.0",
  "rustc-hash",
  "skrifa",
  "write-fonts",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo 0.11.3",
+ "siphasher",
 ]
 
 [[package]]
@@ -1341,6 +1471,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
 name = "tiny-skia-path"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +1532,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-bidi-mirroring"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1574,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f"
 
 [[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,6 +1590,33 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize 0.13.0",
+ "kurbo 0.11.3",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
 
 [[package]]
 name = "utf8parse"
@@ -1805,7 +1995,7 @@ checksum = "886614b5ce857341226aa091f3c285e450683894acaaa7887f366c361efef79d"
 dependencies = [
  "font-types",
  "indexmap",
- "kurbo",
+ "kurbo 0.12.0",
  "log",
  "read-fonts",
 ]
@@ -1815,6 +2005,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xmp-writer"
@@ -1921,10 +2117,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
 name = "zune-jpeg"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
- "zune-core",
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
+dependencies = [
+ "zune-core 0.5.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,14 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 
 # PDF generation
-krilla = "0.5"
+krilla = { version = "0.6", features = ["raster-images"] }
+krilla-svg = "0.3"
+
+# SVG parsing
+usvg = "0.45"
+
+# Markdown parsing
+pulldown-cmark = "0.12"
 parley = "0.6"
 fontdb = "0.23"
 

--- a/examples/markdown_report/config.yaml
+++ b/examples/markdown_report/config.yaml
@@ -1,0 +1,30 @@
+output:
+  mode: single
+  directory: ./output
+  filename: markdown_report_example.pdf
+
+files:
+  - path: ./examples/markdown_report/sample.rs
+
+markdown_report:
+  enabled: true
+  path: ./examples/markdown_report/report.md
+
+cover_page:
+  enabled: true
+  title: Markdown Report Example
+  authors: Papercut Team
+  description: |
+    This example demonstrates the markdown report feature of Papercut.
+    The report content is rendered directly to the PDF after the cover page
+    and table of contents, before the source code listings.
+
+page:
+  size: A4
+  margins:
+    top: 2.5
+    bottom: 2.5
+    left: 2.0
+    right: 2.0
+  font_size: 10
+  line_numbers: true

--- a/examples/markdown_report/report.md
+++ b/examples/markdown_report/report.md
@@ -1,0 +1,73 @@
+# Project Report
+
+This document demonstrates the markdown rendering capabilities of Papercut.
+
+![Papercut Logo](../../assets/logos/papercut_logo.svg)
+
+## Introduction
+
+Papercut can now render markdown documents directly into PDF output alongside source code listings. This enables creating comprehensive technical documentation that combines narrative text with code.
+
+## Features
+
+### Text Formatting
+
+Markdown supports various text formatting options:
+
+- **Bold text** for emphasis
+- *Italic text* for subtle emphasis
+- `Inline code` for technical terms
+- ~~Strikethrough~~ for deprecated content
+
+### Lists
+
+Ordered lists work well for step-by-step instructions:
+
+1. First step
+2. Second step
+3. Third step
+
+Unordered lists are great for features:
+
+- Feature one
+- Feature two
+- Feature three
+  - Nested item A
+  - Nested item B
+
+### Code Blocks
+
+Code blocks are rendered with a monospace font and light background:
+
+```rust
+fn main() {
+    println!("Hello from Papercut!");
+
+    let numbers = vec![1, 2, 3, 4, 5];
+    for n in numbers {
+        println!("Number: {}", n);
+    }
+}
+```
+
+### Blockquotes
+
+> Blockquotes are useful for highlighting important information
+> or quoting external sources. They are rendered with a left border
+> to visually distinguish them from regular text.
+
+### Links
+
+For more information, visit [Papercut on GitHub](https://github.com/chrislupp/papercut).
+
+---
+
+## Conclusion
+
+The markdown report feature provides a powerful way to include documentation directly in your PDF output without requiring external tools or PDF merging.
+
+### Future Extensions
+
+Math support is designed as a future extension point. Currently, math expressions like $E = mc^2$ are rendered as inline code.
+
+---

--- a/examples/markdown_report/sample.rs
+++ b/examples/markdown_report/sample.rs
@@ -1,0 +1,60 @@
+// Sample Rust file for Papercut markdown report example
+//
+// This file demonstrates how source code is rendered alongside
+// the markdown report in the final PDF output.
+
+fn main() {
+    println!("Hello from Papercut!");
+
+    let message = create_greeting("World");
+    println!("{}", message);
+
+    demonstrate_features();
+}
+
+/// Creates a greeting message for the given name
+fn create_greeting(name: &str) -> String {
+    format!("Hello, {}!", name)
+}
+
+/// Demonstrates various Rust features for syntax highlighting
+fn demonstrate_features() {
+    // Variables and types
+    let count: i32 = 42;
+    let pi: f64 = 3.14159;
+    let is_active: bool = true;
+
+    // Collections
+    let numbers = vec![1, 2, 3, 4, 5];
+    let mut map = std::collections::HashMap::new();
+    map.insert("key", "value");
+
+    // Control flow
+    for (i, num) in numbers.iter().enumerate() {
+        if *num % 2 == 0 {
+            println!("Index {}: {} is even", i, num);
+        } else {
+            println!("Index {}: {} is odd", i, num);
+        }
+    }
+
+    // Pattern matching
+    match count {
+        0 => println!("Zero"),
+        1..=10 => println!("Small number"),
+        _ => println!("Large number: {}", count),
+    }
+
+    println!("Pi: {}, Active: {}", pi, is_active);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_greeting() {
+        let result = create_greeting("Test");
+        assert_eq!(result, "Hello, Test!");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,6 +173,8 @@ pub struct Config {
     pub warnings: WarningsConfig,
     #[serde(default)]
     pub cover_page: CoverPageConfig,
+    #[serde(default)]
+    pub markdown_report: MarkdownReportConfig,
 }
 
 /// Expanded file entry after pattern matching
@@ -497,6 +499,16 @@ impl Default for CoverPageConfig {
             footer: None,
         }
     }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct MarkdownReportConfig {
+    /// Enable or disable the markdown report
+    #[serde(default)]
+    pub enabled: bool,
+    /// Path to the markdown file (relative to config file or absolute)
+    #[serde(default)]
+    pub path: PathBuf,
 }
 
 // Default value functions

--- a/src/pdf/generator.rs
+++ b/src/pdf/generator.rs
@@ -32,6 +32,7 @@ use crate::pdf::krilla_doc::PdfContext;
 use crate::pdf::colors::{rgb_to_paint, syntect_to_paint};
 use crate::pdf::cover_page;
 use crate::pdf::header_footer::{self, HeaderFooterContext};
+use crate::pdf::markdown_renderer::{render_markdown, MarkdownRenderContext};
 use crate::warnings::WarningManager;
 use chrono::Local;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -498,6 +499,92 @@ fn generate_single_pdf(config: Config, verbose: bool, force: bool, warning_manag
         )?;
     } else {
         // No cover page - render header on first page
+        let hf_ctx = HeaderFooterContext {
+            page_number: current_page_num,
+            total_pages,
+            current_filename: &current_filename,
+            date: &date_str,
+        };
+        header_footer::render_header(
+            &mut surface,
+            hf_font.clone(),
+            &config.header,
+            &hf_ctx,
+            ctx.margin_left,
+            ctx.margin_top,
+            ctx.content_width,
+            ctx.page_width_mm,
+            ctx.margin_right,
+        )?;
+    }
+
+    // Render markdown report if enabled (after cover/TOC, before source code)
+    if config.markdown_report.enabled && !config.markdown_report.path.as_os_str().is_empty() {
+        // Finish current page before markdown rendering takes over
+        header_footer::render_footer(
+            &mut surface,
+            hf_font.clone(),
+            &config.footer,
+            &HeaderFooterContext {
+                page_number: current_page_num,
+                total_pages,
+                current_filename: &current_filename,
+                date: &date_str,
+            },
+            ctx.margin_left,
+            ctx.page_height_mm,
+            ctx.margin_bottom,
+            ctx.content_width,
+            ctx.page_width_mm,
+            ctx.margin_right,
+        )?;
+        surface.finish();
+        page.finish();
+
+        // Determine base directory for resolving relative image paths
+        let base_dir = config.markdown_report.path
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+
+        if verbose {
+            println!("  Rendering markdown report: {}", config.markdown_report.path.display());
+        }
+
+        // Create markdown render context
+        let md_ctx = MarkdownRenderContext {
+            base_dir,
+            page_settings: ctx.page_settings(),
+            margin_left: ctx.margin_left,
+            margin_top: ctx.margin_top,
+            margin_right: ctx.margin_right,
+            margin_bottom: ctx.margin_bottom,
+            content_width: ctx.content_width,
+            content_height: ctx.content_height,
+            page_width: ctx.page_width_mm,
+            page_height: ctx.page_height_mm,
+            start_page_num: current_page_num + 1,
+            total_pages,
+            date_str: date_str.clone(),
+        };
+
+        // Render markdown
+        let (_pages_created, final_page) = render_markdown(
+            &mut ctx.document,
+            &mut ctx.font_manager,
+            &config,
+            &config.markdown_report.path,
+            md_ctx,
+        )?;
+        current_page_num = final_page;
+
+        // Start new page for source code
+        page = ctx.document.start_page_with(ctx.page_settings());
+        surface = page.surface();
+        current_y = ctx.margin_top;
+        current_page_num += 1;
+
+        // Render header on first source code page
         let hf_ctx = HeaderFooterContext {
             page_number: current_page_num,
             total_pages,

--- a/src/pdf/krilla_doc.rs
+++ b/src/pdf/krilla_doc.rs
@@ -30,9 +30,10 @@ use crate::config::{Config, EffectiveMetadata, PageSize};
 use crate::error::{PapercutError, Result};
 use crate::pdf::fonts::FontManager;
 use crate::warnings::WarningManager;
-use krilla::Document;
+use krilla::geom::Size;
 use krilla::metadata::Metadata;
 use krilla::page::PageSettings;
+use krilla::Document;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -86,7 +87,9 @@ impl PdfContext {
 
     /// Get page settings for creating a new page
     pub fn page_settings(&self) -> PageSettings {
-        PageSettings::new(self.page_width_mm, self.page_height_mm)
+        let size = Size::from_wh(self.page_width_mm, self.page_height_mm)
+            .expect("Invalid page dimensions");
+        PageSettings::new(size)
     }
 
     /// Set PDF metadata from effective metadata (merged config + cover page)

--- a/src/pdf/markdown_renderer.rs
+++ b/src/pdf/markdown_renderer.rs
@@ -1,0 +1,1178 @@
+// Papercut - Source code to PDF converter
+// Copyright (C) 2025-2026 Christopher A. Lupp
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// Distribution A: This work has been cleared for public release,
+// distribution unlimited, case number: AFRL-2026-0405. The views expressed
+// are those of the authors and do not reflect the official guidance or
+// position of the United States Government, the Department of Defense or of
+// the United States Air Force.
+//
+// Statement from DoD: The Appearance of external hyperlinks does not
+// constitute endorsement by the United States Department of Defense (DoD) of
+// the linked websites, of the information, products, or services contained
+// therein. The DoD does not exercise any editorial, security, or other
+// control over the information you may find at these locations.
+
+use crate::config::Config;
+use crate::error::{PapercutError, Result};
+use crate::pdf::colors::rgb_to_paint;
+use crate::pdf::fonts::FontManager;
+use crate::pdf::header_footer::{self, HeaderFooterContext};
+use krilla::action::{Action, LinkAction};
+use krilla::annotation::{Annotation, LinkAnnotation, Target};
+use krilla::geom::{PathBuilder, Point, Rect, Size, Transform};
+use krilla::image::Image;
+use krilla::num::NormalizedF32;
+use krilla::page::PageSettings;
+use krilla::paint::{Fill, Stroke};
+use krilla::surface::Surface;
+use krilla::text::TextDirection;
+use krilla::Document;
+use krilla_svg::{SurfaceExt, SvgSettings};
+use parley::layout::{Alignment, AlignmentOptions, PositionedLayoutItem};
+use parley::style::{FontStack, LineHeight, StyleProperty};
+use parley::{FontContext, Layout, LayoutContext};
+use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use std::borrow::Cow;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use usvg::{Options as UsvgOptions, Tree as SvgTree};
+
+/// Link annotation data for markdown links
+struct MarkdownLink {
+    rect: Rect,
+    url: String,
+}
+
+/// Context for rendering markdown pages
+pub struct MarkdownRenderContext {
+    pub base_dir: PathBuf,
+    pub page_settings: PageSettings,
+    pub margin_left: f32,
+    pub margin_top: f32,
+    pub margin_right: f32,
+    pub margin_bottom: f32,
+    pub content_width: f32,
+    #[allow(dead_code)]
+    pub content_height: f32,
+    pub page_width: f32,
+    pub page_height: f32,
+    pub start_page_num: usize,
+    pub total_pages: usize,
+    pub date_str: String,
+}
+
+/// Text style state for rich text rendering
+#[derive(Clone, Default)]
+struct TextStyle {
+    bold: bool,
+    #[allow(dead_code)]
+    italic: bool,
+    #[allow(dead_code)]
+    code: bool,
+}
+
+/// A segment of styled text
+struct StyledText {
+    text: String,
+    style: TextStyle,
+}
+
+/// Render a markdown file to the document
+/// Returns (pages_created, final_page_number)
+pub fn render_markdown(
+    document: &mut Document,
+    font_manager: &mut FontManager,
+    config: &Config,
+    markdown_path: &Path,
+    ctx: MarkdownRenderContext,
+) -> Result<(usize, usize)> {
+    // Read markdown content
+    let content = fs::read_to_string(markdown_path).map_err(|e| PapercutError::FileRead {
+        path: markdown_path.display().to_string(),
+        source: e,
+    })?;
+
+    // Parse markdown with common extensions
+    let options =
+        Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH | Options::ENABLE_FOOTNOTES;
+    let parser = Parser::new_ext(&content, options);
+    let events: Vec<Event> = parser.collect();
+
+    // Get fonts for krilla drawing
+    let font = font_manager.get_cover_font("Arial")?;
+    let bold_font = font_manager.get_cover_bold_font("Arial")?;
+    let mono_font = font_manager.get_monospace_font()?;
+    let hf_font = font_manager.get_header_footer_font()?;
+
+    // Initialize parley for text layout
+    let mut font_cx = FontContext::new();
+    let mut layout_cx = LayoutContext::new();
+
+    // Font sizes
+    let base_font_size = config.cover_page.text_font_size as f32;
+    let line_height = base_font_size * 1.5;
+
+    // State tracking
+    let mut current_page_num = ctx.start_page_num;
+    let mut current_y = ctx.margin_top;
+    let mut pending_links: Vec<MarkdownLink> = Vec::new();
+
+    // Markdown state
+    let mut current_heading_level: Option<HeadingLevel> = None;
+    let mut in_blockquote = false;
+    let mut in_code_block = false;
+    let mut code_block_content = String::new();
+    let mut list_stack: Vec<Option<u64>> = Vec::new();
+    let mut current_link_url: Option<String> = None;
+    let mut link_start_x: f32 = 0.0;
+    let mut link_start_y: f32 = 0.0;
+    let mut current_style = TextStyle::default();
+    let mut styled_segments: Vec<StyledText> = Vec::new();
+
+    // Start first page
+    let mut page = document.start_page_with(ctx.page_settings.clone());
+    {
+        let mut surface = page.surface();
+
+        // Render header on first page
+        render_header_helper(
+            &mut surface,
+            &hf_font,
+            config,
+            current_page_num,
+            ctx.total_pages,
+            &ctx.date_str,
+            ctx.margin_left,
+            ctx.margin_top,
+            ctx.content_width,
+            ctx.page_width,
+            ctx.margin_right,
+        )?;
+
+        // Process all events
+        for event in &events {
+            match event {
+                Event::Start(tag) => match tag {
+                    Tag::Heading { level, .. } => {
+                        // Flush any accumulated text first
+                        if !styled_segments.is_empty() {
+                            current_y = render_styled_text(
+                                &mut surface,
+                                &styled_segments,
+                                &mut font_cx,
+                                &mut layout_cx,
+                                &font,
+                                &bold_font,
+                                base_font_size,
+                                ctx.margin_left,
+                                current_y,
+                                ctx.content_width,
+                            );
+                            styled_segments.clear();
+                        }
+                        current_heading_level = Some(*level);
+                        current_y += line_height * 0.5;
+                    }
+                    Tag::Paragraph => {
+                        // Flush any accumulated text
+                        if !styled_segments.is_empty() {
+                            current_y = render_styled_text(
+                                &mut surface,
+                                &styled_segments,
+                                &mut font_cx,
+                                &mut layout_cx,
+                                &font,
+                                &bold_font,
+                                base_font_size,
+                                ctx.margin_left,
+                                current_y,
+                                ctx.content_width,
+                            );
+                            styled_segments.clear();
+                        }
+                    }
+                    Tag::BlockQuote(_) => {
+                        in_blockquote = true;
+                    }
+                    Tag::CodeBlock(_) => {
+                        in_code_block = true;
+                        code_block_content.clear();
+                        current_y += line_height * 0.5;
+                    }
+                    Tag::List(start) => {
+                        list_stack.push(*start);
+                    }
+                    Tag::Item => {
+                        // Flush any accumulated text
+                        if !styled_segments.is_empty() {
+                            current_y = render_styled_text(
+                                &mut surface,
+                                &styled_segments,
+                                &mut font_cx,
+                                &mut layout_cx,
+                                &font,
+                                &bold_font,
+                                base_font_size,
+                                ctx.margin_left,
+                                current_y,
+                                ctx.content_width,
+                            );
+                            styled_segments.clear();
+                        }
+
+                        // Check for page break
+                        if current_y + line_height > ctx.page_height - ctx.margin_bottom {
+                            render_footer_helper(
+                                &mut surface,
+                                &hf_font,
+                                config,
+                                current_page_num,
+                                ctx.total_pages,
+                                &ctx.date_str,
+                                ctx.margin_left,
+                                ctx.page_height,
+                                ctx.margin_bottom,
+                                ctx.content_width,
+                                ctx.page_width,
+                                ctx.margin_right,
+                            )?;
+                            surface.finish();
+                            add_link_annotations(&mut page, &mut pending_links);
+                            page.finish();
+                            current_page_num += 1;
+
+                            page = document.start_page_with(ctx.page_settings.clone());
+                            surface = page.surface();
+                            current_y = ctx.margin_top;
+                            render_header_helper(
+                                &mut surface,
+                                &hf_font,
+                                config,
+                                current_page_num,
+                                ctx.total_pages,
+                                &ctx.date_str,
+                                ctx.margin_left,
+                                ctx.margin_top,
+                                ctx.content_width,
+                                ctx.page_width,
+                                ctx.margin_right,
+                            )?;
+                        }
+
+                        let indent = (list_stack.len() - 1) as f32 * 20.0;
+                        let bullet_x = ctx.margin_left + indent;
+
+                        // Draw bullet or number
+                        if let Some(Some(num)) = list_stack.last() {
+                            let number_text = format!("{}.", num);
+                            surface.draw_text(
+                                Point::from_xy(bullet_x, current_y + base_font_size),
+                                font.as_ref().clone(),
+                                base_font_size,
+                                &number_text,
+                                false,
+                                TextDirection::Auto,
+                            );
+                            if let Some(Some(ref mut n)) = list_stack.last_mut() {
+                                *n += 1;
+                            }
+                        } else {
+                            surface.draw_text(
+                                Point::from_xy(bullet_x, current_y + base_font_size),
+                                font.as_ref().clone(),
+                                base_font_size,
+                                "\u{2022}",
+                                false,
+                                TextDirection::Auto,
+                            );
+                        }
+                    }
+                    Tag::Emphasis => {
+                        current_style.italic = true;
+                    }
+                    Tag::Strong => {
+                        current_style.bold = true;
+                    }
+                    Tag::Link { dest_url, .. } => {
+                        // Flush text before link
+                        if !styled_segments.is_empty() {
+                            current_y = render_styled_text(
+                                &mut surface,
+                                &styled_segments,
+                                &mut font_cx,
+                                &mut layout_cx,
+                                &font,
+                                &bold_font,
+                                base_font_size,
+                                ctx.margin_left,
+                                current_y,
+                                ctx.content_width,
+                            );
+                            styled_segments.clear();
+                        }
+                        current_link_url = Some(dest_url.to_string());
+                        link_start_x = ctx.margin_left;
+                        link_start_y = current_y;
+                    }
+                    Tag::Image { dest_url, .. } => {
+                        let image_path = ctx.base_dir.join(dest_url.as_ref());
+                        let extension = image_path
+                            .extension()
+                            .and_then(|e| e.to_str())
+                            .map(|s| s.to_lowercase())
+                            .unwrap_or_default();
+
+                        if extension == "svg" {
+                            // Handle SVG as vector graphics
+                            if let Ok(svg_data) = fs::read(&image_path) {
+                                // Parse SVG with usvg
+                                let opts = UsvgOptions::default();
+                                if let Ok(svg_tree) = SvgTree::from_data(&svg_data, &opts) {
+                                    let max_width = ctx.content_width;
+                                    let max_height = 300.0;
+
+                                    // Get SVG dimensions from the tree
+                                    let svg_size = svg_tree.size();
+                                    let svg_width = svg_size.width();
+                                    let svg_height = svg_size.height();
+
+                                    let scale = (max_width / svg_width)
+                                        .min(max_height / svg_height)
+                                        .min(1.0);
+
+                                    let display_width = svg_width * scale;
+                                    let display_height = svg_height * scale;
+
+                                    // Check for page break
+                                    if current_y + display_height
+                                        > ctx.page_height - ctx.margin_bottom
+                                    {
+                                        render_footer_helper(
+                                            &mut surface,
+                                            &hf_font,
+                                            config,
+                                            current_page_num,
+                                            ctx.total_pages,
+                                            &ctx.date_str,
+                                            ctx.margin_left,
+                                            ctx.page_height,
+                                            ctx.margin_bottom,
+                                            ctx.content_width,
+                                            ctx.page_width,
+                                            ctx.margin_right,
+                                        )?;
+                                        surface.finish();
+                                        add_link_annotations(&mut page, &mut pending_links);
+                                        page.finish();
+                                        current_page_num += 1;
+
+                                        page = document.start_page_with(ctx.page_settings.clone());
+                                        surface = page.surface();
+                                        current_y = ctx.margin_top;
+                                        render_header_helper(
+                                            &mut surface,
+                                            &hf_font,
+                                            config,
+                                            current_page_num,
+                                            ctx.total_pages,
+                                            &ctx.date_str,
+                                            ctx.margin_left,
+                                            ctx.margin_top,
+                                            ctx.content_width,
+                                            ctx.page_width,
+                                            ctx.margin_right,
+                                        )?;
+                                    }
+
+                                    // Center the SVG
+                                    let image_x =
+                                        ctx.margin_left + (ctx.content_width - display_width) / 2.0;
+
+                                    // Draw SVG as vector graphics
+                                    // First translate to position, then apply scale
+                                    let translate_transform =
+                                        Transform::from_translate(image_x, current_y);
+                                    surface.push_transform(&translate_transform);
+
+                                    // Draw at scaled size
+                                    if let Some(size) =
+                                        Size::from_wh(display_width, display_height)
+                                    {
+                                        let settings = SvgSettings::default();
+                                        let _ = surface.draw_svg(&svg_tree, size, settings);
+                                    }
+                                    surface.pop();
+
+                                    current_y += display_height + line_height;
+                                }
+                            }
+                        } else if let Some(image) = load_image(&image_path) {
+                            // Handle raster images (PNG, JPEG, GIF, WebP)
+                            let (img_width, img_height) = image.size();
+                            let max_width = ctx.content_width;
+                            let max_height = 300.0;
+
+                            let scale = (max_width / img_width as f32)
+                                .min(max_height / img_height as f32)
+                                .min(1.0);
+
+                            let display_width = img_width as f32 * scale;
+                            let display_height = img_height as f32 * scale;
+
+                            // Check for page break
+                            if current_y + display_height > ctx.page_height - ctx.margin_bottom {
+                                render_footer_helper(
+                                    &mut surface,
+                                    &hf_font,
+                                    config,
+                                    current_page_num,
+                                    ctx.total_pages,
+                                    &ctx.date_str,
+                                    ctx.margin_left,
+                                    ctx.page_height,
+                                    ctx.margin_bottom,
+                                    ctx.content_width,
+                                    ctx.page_width,
+                                    ctx.margin_right,
+                                )?;
+                                surface.finish();
+                                add_link_annotations(&mut page, &mut pending_links);
+                                page.finish();
+                                current_page_num += 1;
+
+                                page = document.start_page_with(ctx.page_settings.clone());
+                                surface = page.surface();
+                                current_y = ctx.margin_top;
+                                render_header_helper(
+                                    &mut surface,
+                                    &hf_font,
+                                    config,
+                                    current_page_num,
+                                    ctx.total_pages,
+                                    &ctx.date_str,
+                                    ctx.margin_left,
+                                    ctx.margin_top,
+                                    ctx.content_width,
+                                    ctx.page_width,
+                                    ctx.margin_right,
+                                )?;
+                            }
+
+                            // Center the image
+                            let image_x =
+                                ctx.margin_left + (ctx.content_width - display_width) / 2.0;
+
+                            // Draw image
+                            let transform = Transform::from_translate(image_x, current_y);
+                            surface.push_transform(&transform);
+                            if let Some(size) = Size::from_wh(display_width, display_height) {
+                                surface.draw_image(image, size);
+                            }
+                            surface.pop();
+
+                            current_y += display_height + line_height;
+                        }
+                    }
+                    _ => {}
+                },
+                Event::End(tag_end) => match tag_end {
+                    TagEnd::Heading(_) => {
+                        let heading_font_size = match current_heading_level {
+                            Some(HeadingLevel::H1) => base_font_size * 2.0,
+                            Some(HeadingLevel::H2) => base_font_size * 1.7,
+                            Some(HeadingLevel::H3) => base_font_size * 1.4,
+                            Some(HeadingLevel::H4) => base_font_size * 1.2,
+                            Some(HeadingLevel::H5) => base_font_size * 1.1,
+                            _ => base_font_size,
+                        };
+                        let heading_line_height = heading_font_size * 1.5;
+
+                        // Check for page break
+                        if current_y + heading_line_height > ctx.page_height - ctx.margin_bottom {
+                            render_footer_helper(
+                                &mut surface,
+                                &hf_font,
+                                config,
+                                current_page_num,
+                                ctx.total_pages,
+                                &ctx.date_str,
+                                ctx.margin_left,
+                                ctx.page_height,
+                                ctx.margin_bottom,
+                                ctx.content_width,
+                                ctx.page_width,
+                                ctx.margin_right,
+                            )?;
+                            surface.finish();
+                            add_link_annotations(&mut page, &mut pending_links);
+                            page.finish();
+                            current_page_num += 1;
+
+                            page = document.start_page_with(ctx.page_settings.clone());
+                            surface = page.surface();
+                            current_y = ctx.margin_top;
+                            render_header_helper(
+                                &mut surface,
+                                &hf_font,
+                                config,
+                                current_page_num,
+                                ctx.total_pages,
+                                &ctx.date_str,
+                                ctx.margin_left,
+                                ctx.margin_top,
+                                ctx.content_width,
+                                ctx.page_width,
+                                ctx.margin_right,
+                            )?;
+                        }
+
+                        // Combine all styled segments into plain text for heading
+                        let heading_text: String =
+                            styled_segments.iter().map(|s| s.text.as_str()).collect();
+
+                        surface.draw_text(
+                            Point::from_xy(ctx.margin_left, current_y + heading_font_size),
+                            bold_font.as_ref().clone(),
+                            heading_font_size,
+                            &heading_text,
+                            false,
+                            TextDirection::Auto,
+                        );
+
+                        current_y += heading_line_height;
+                        styled_segments.clear();
+                        current_heading_level = None;
+                    }
+                    TagEnd::Paragraph => {
+                        if !styled_segments.is_empty() {
+                            let draw_x = if in_blockquote {
+                                ctx.margin_left + 20.0
+                            } else {
+                                ctx.margin_left
+                            };
+                            let available_width = if in_blockquote {
+                                ctx.content_width - 20.0
+                            } else {
+                                ctx.content_width
+                            };
+
+                            // Combine segments into full text
+                            let full_text: String =
+                                styled_segments.iter().map(|s| s.text.as_str()).collect();
+
+                            // Use parley for proper line breaking
+                            let lines = calculate_line_breaks(
+                                &full_text,
+                                &mut font_cx,
+                                &mut layout_cx,
+                                base_font_size,
+                                available_width,
+                            );
+
+                            // Render each line
+                            for line_text in lines {
+                                // Check for page break
+                                if current_y + line_height > ctx.page_height - ctx.margin_bottom {
+                                    render_footer_helper(
+                                        &mut surface,
+                                        &hf_font,
+                                        config,
+                                        current_page_num,
+                                        ctx.total_pages,
+                                        &ctx.date_str,
+                                        ctx.margin_left,
+                                        ctx.page_height,
+                                        ctx.margin_bottom,
+                                        ctx.content_width,
+                                        ctx.page_width,
+                                        ctx.margin_right,
+                                    )?;
+                                    surface.finish();
+                                    add_link_annotations(&mut page, &mut pending_links);
+                                    page.finish();
+                                    current_page_num += 1;
+
+                                    page = document.start_page_with(ctx.page_settings.clone());
+                                    surface = page.surface();
+                                    current_y = ctx.margin_top;
+                                    render_header_helper(
+                                        &mut surface,
+                                        &hf_font,
+                                        config,
+                                        current_page_num,
+                                        ctx.total_pages,
+                                        &ctx.date_str,
+                                        ctx.margin_left,
+                                        ctx.margin_top,
+                                        ctx.content_width,
+                                        ctx.page_width,
+                                        ctx.margin_right,
+                                    )?;
+                                }
+
+                                surface.draw_text(
+                                    Point::from_xy(draw_x, current_y + base_font_size),
+                                    font.as_ref().clone(),
+                                    base_font_size,
+                                    &line_text,
+                                    false,
+                                    TextDirection::Auto,
+                                );
+                                current_y += line_height;
+                            }
+
+                            styled_segments.clear();
+                        }
+                        current_y += line_height * 0.5;
+                    }
+                    TagEnd::BlockQuote(_) => {
+                        in_blockquote = false;
+                    }
+                    TagEnd::CodeBlock => {
+                        let code_font_size = base_font_size * 0.9;
+                        let code_line_height = code_font_size * 1.3;
+                        let code_lines: Vec<&str> = code_block_content.lines().collect();
+                        let block_height = (code_lines.len() as f32 * code_line_height) + 10.0;
+
+                        // Check for page break
+                        if current_y + block_height > ctx.page_height - ctx.margin_bottom {
+                            render_footer_helper(
+                                &mut surface,
+                                &hf_font,
+                                config,
+                                current_page_num,
+                                ctx.total_pages,
+                                &ctx.date_str,
+                                ctx.margin_left,
+                                ctx.page_height,
+                                ctx.margin_bottom,
+                                ctx.content_width,
+                                ctx.page_width,
+                                ctx.margin_right,
+                            )?;
+                            surface.finish();
+                            add_link_annotations(&mut page, &mut pending_links);
+                            page.finish();
+                            current_page_num += 1;
+
+                            page = document.start_page_with(ctx.page_settings.clone());
+                            surface = page.surface();
+                            current_y = ctx.margin_top;
+                            render_header_helper(
+                                &mut surface,
+                                &hf_font,
+                                config,
+                                current_page_num,
+                                ctx.total_pages,
+                                &ctx.date_str,
+                                ctx.margin_left,
+                                ctx.margin_top,
+                                ctx.content_width,
+                                ctx.page_width,
+                                ctx.margin_right,
+                            )?;
+                        }
+
+                        // Draw code block background
+                        if let Some(rect) = Rect::from_xywh(
+                            ctx.margin_left,
+                            current_y,
+                            ctx.content_width,
+                            block_height,
+                        ) {
+                            let mut path_builder = PathBuilder::new();
+                            path_builder.push_rect(rect);
+                            if let Some(path) = path_builder.finish() {
+                                surface.set_fill(Some(Fill {
+                                    paint: rgb_to_paint(245, 245, 245),
+                                    opacity: NormalizedF32::ONE,
+                                    rule: Default::default(),
+                                }));
+                                surface.draw_path(&path);
+                                surface.set_fill(None);
+                            }
+                        }
+
+                        current_y += 5.0;
+                        for line in code_lines {
+                            surface.draw_text(
+                                Point::from_xy(
+                                    ctx.margin_left + 10.0,
+                                    current_y + code_font_size,
+                                ),
+                                mono_font.as_ref().clone(),
+                                code_font_size,
+                                line,
+                                false,
+                                TextDirection::Auto,
+                            );
+                            current_y += code_line_height;
+                        }
+
+                        current_y += 5.0 + line_height * 0.5;
+                        in_code_block = false;
+                        code_block_content.clear();
+                    }
+                    TagEnd::List(_) => {
+                        list_stack.pop();
+                        if list_stack.is_empty() {
+                            current_y += line_height * 0.5;
+                        }
+                    }
+                    TagEnd::Item => {
+                        if !styled_segments.is_empty() {
+                            let indent = (list_stack.len() - 1) as f32 * 20.0;
+                            let item_x = ctx.margin_left + indent + 20.0;
+                            let available_width = ctx.content_width - indent - 20.0;
+
+                            // Combine segments into full text
+                            let full_text: String =
+                                styled_segments.iter().map(|s| s.text.as_str()).collect();
+
+                            // Use parley for proper line breaking
+                            let lines = calculate_line_breaks(
+                                &full_text,
+                                &mut font_cx,
+                                &mut layout_cx,
+                                base_font_size,
+                                available_width,
+                            );
+
+                            // Render each line
+                            for line_text in lines {
+                                // Check for page break
+                                if current_y + line_height > ctx.page_height - ctx.margin_bottom {
+                                    render_footer_helper(
+                                        &mut surface,
+                                        &hf_font,
+                                        config,
+                                        current_page_num,
+                                        ctx.total_pages,
+                                        &ctx.date_str,
+                                        ctx.margin_left,
+                                        ctx.page_height,
+                                        ctx.margin_bottom,
+                                        ctx.content_width,
+                                        ctx.page_width,
+                                        ctx.margin_right,
+                                    )?;
+                                    surface.finish();
+                                    add_link_annotations(&mut page, &mut pending_links);
+                                    page.finish();
+                                    current_page_num += 1;
+
+                                    page = document.start_page_with(ctx.page_settings.clone());
+                                    surface = page.surface();
+                                    current_y = ctx.margin_top;
+                                    render_header_helper(
+                                        &mut surface,
+                                        &hf_font,
+                                        config,
+                                        current_page_num,
+                                        ctx.total_pages,
+                                        &ctx.date_str,
+                                        ctx.margin_left,
+                                        ctx.margin_top,
+                                        ctx.content_width,
+                                        ctx.page_width,
+                                        ctx.margin_right,
+                                    )?;
+                                }
+
+                                surface.draw_text(
+                                    Point::from_xy(item_x, current_y + base_font_size),
+                                    font.as_ref().clone(),
+                                    base_font_size,
+                                    &line_text,
+                                    false,
+                                    TextDirection::Auto,
+                                );
+                                current_y += line_height;
+                            }
+
+                            styled_segments.clear();
+                        } else {
+                            // Even if no text, advance past the bullet line
+                            current_y += line_height;
+                        }
+                    }
+                    TagEnd::Emphasis => {
+                        current_style.italic = false;
+                    }
+                    TagEnd::Strong => {
+                        current_style.bold = false;
+                    }
+                    TagEnd::Link => {
+                        if let Some(url) = &current_link_url {
+                            // Render link text
+                            let link_text: String =
+                                styled_segments.iter().map(|s| s.text.as_str()).collect();
+                            let text_width = estimate_text_width(&link_text, base_font_size);
+
+                            // Draw link text in blue
+                            surface.set_fill(Some(Fill {
+                                paint: rgb_to_paint(0, 102, 204),
+                                opacity: NormalizedF32::ONE,
+                                rule: Default::default(),
+                            }));
+                            surface.draw_text(
+                                Point::from_xy(link_start_x, link_start_y + base_font_size),
+                                font.as_ref().clone(),
+                                base_font_size,
+                                &link_text,
+                                false,
+                                TextDirection::Auto,
+                            );
+                            surface.set_fill(None);
+
+                            // Draw underline
+                            let underline_y = link_start_y + base_font_size + 2.0;
+                            let mut path_builder = PathBuilder::new();
+                            path_builder.move_to(link_start_x, underline_y);
+                            path_builder.line_to(link_start_x + text_width, underline_y);
+                            if let Some(path) = path_builder.finish() {
+                                surface.set_stroke(Some(Stroke {
+                                    paint: rgb_to_paint(0, 102, 204),
+                                    width: 0.5,
+                                    ..Default::default()
+                                }));
+                                surface.draw_path(&path);
+                                surface.set_stroke(None);
+                            }
+
+                            // Store link annotation
+                            if let Some(rect) =
+                                Rect::from_xywh(link_start_x, link_start_y, text_width, line_height)
+                            {
+                                pending_links.push(MarkdownLink {
+                                    rect,
+                                    url: url.clone(),
+                                });
+                            }
+
+                            styled_segments.clear();
+                        }
+                        current_link_url = None;
+                    }
+                    _ => {}
+                },
+                Event::Text(text) => {
+                    if in_code_block {
+                        code_block_content.push_str(text);
+                    } else {
+                        styled_segments.push(StyledText {
+                            text: text.to_string(),
+                            style: current_style.clone(),
+                        });
+                    }
+                }
+                Event::Code(code) => {
+                    styled_segments.push(StyledText {
+                        text: format!("`{}`", code),
+                        style: TextStyle {
+                            code: true,
+                            ..current_style.clone()
+                        },
+                    });
+                }
+                Event::SoftBreak => {
+                    styled_segments.push(StyledText {
+                        text: " ".to_string(),
+                        style: current_style.clone(),
+                    });
+                }
+                Event::HardBreak => {
+                    styled_segments.push(StyledText {
+                        text: "\n".to_string(),
+                        style: current_style.clone(),
+                    });
+                }
+                Event::Rule => {
+                    current_y += line_height * 0.5;
+
+                    if current_y + 10.0 > ctx.page_height - ctx.margin_bottom {
+                        render_footer_helper(
+                            &mut surface,
+                            &hf_font,
+                            config,
+                            current_page_num,
+                            ctx.total_pages,
+                            &ctx.date_str,
+                            ctx.margin_left,
+                            ctx.page_height,
+                            ctx.margin_bottom,
+                            ctx.content_width,
+                            ctx.page_width,
+                            ctx.margin_right,
+                        )?;
+                        surface.finish();
+                        add_link_annotations(&mut page, &mut pending_links);
+                        page.finish();
+                        current_page_num += 1;
+
+                        page = document.start_page_with(ctx.page_settings.clone());
+                        surface = page.surface();
+                        current_y = ctx.margin_top;
+                        render_header_helper(
+                            &mut surface,
+                            &hf_font,
+                            config,
+                            current_page_num,
+                            ctx.total_pages,
+                            &ctx.date_str,
+                            ctx.margin_left,
+                            ctx.margin_top,
+                            ctx.content_width,
+                            ctx.page_width,
+                            ctx.margin_right,
+                        )?;
+                    }
+
+                    let mut path_builder = PathBuilder::new();
+                    path_builder.move_to(ctx.margin_left, current_y);
+                    path_builder.line_to(ctx.margin_left + ctx.content_width, current_y);
+                    if let Some(path) = path_builder.finish() {
+                        surface.set_stroke(Some(Stroke {
+                            paint: rgb_to_paint(180, 180, 180),
+                            width: 1.0,
+                            ..Default::default()
+                        }));
+                        surface.draw_path(&path);
+                        surface.set_stroke(None);
+                    }
+                    current_y += line_height * 0.5;
+                }
+                _ => {}
+            }
+        }
+
+        // Finish the last page
+        render_footer_helper(
+            &mut surface,
+            &hf_font,
+            config,
+            current_page_num,
+            ctx.total_pages,
+            &ctx.date_str,
+            ctx.margin_left,
+            ctx.page_height,
+            ctx.margin_bottom,
+            ctx.content_width,
+            ctx.page_width,
+            ctx.margin_right,
+        )?;
+        surface.finish();
+    }
+
+    add_link_annotations(&mut page, &mut pending_links);
+    page.finish();
+
+    let pages_created = current_page_num - ctx.start_page_num + 1;
+    Ok((pages_created, current_page_num))
+}
+
+/// Use parley to calculate line breaks and return wrapped lines
+fn calculate_line_breaks(
+    text: &str,
+    font_cx: &mut FontContext,
+    layout_cx: &mut LayoutContext,
+    font_size: f32,
+    max_width: f32,
+) -> Vec<String> {
+    if text.trim().is_empty() {
+        return vec![];
+    }
+
+    // Build layout with parley
+    let mut builder = layout_cx.ranged_builder(font_cx, text, 1.0, false);
+
+    // Push default styles
+    builder.push_default(StyleProperty::FontSize(font_size));
+    builder.push_default(StyleProperty::LineHeight(LineHeight::FontSizeRelative(1.5)));
+    builder.push_default(StyleProperty::FontStack(FontStack::Source(Cow::Borrowed("Arial"))));
+
+    // Build the layout
+    let mut layout: Layout<[u8; 4]> = builder.build(text);
+    layout.break_all_lines(Some(max_width));
+    layout.align(Some(max_width), Alignment::Start, AlignmentOptions::default());
+
+    // Extract line texts
+    let mut lines = Vec::new();
+    for line in layout.lines() {
+        let mut line_text = String::new();
+        for item in line.items() {
+            if let PositionedLayoutItem::GlyphRun(run) = item {
+                let text_range = run.run().text_range();
+                line_text.push_str(&text[text_range]);
+            }
+        }
+        if !line_text.is_empty() {
+            lines.push(line_text);
+        }
+    }
+
+    if lines.is_empty() && !text.trim().is_empty() {
+        // Fallback if parley didn't produce lines
+        lines.push(text.to_string());
+    }
+
+    lines
+}
+
+/// Render styled text (simplified version for headings)
+#[allow(clippy::too_many_arguments)]
+fn render_styled_text(
+    surface: &mut Surface,
+    segments: &[StyledText],
+    _font_cx: &mut FontContext,
+    _layout_cx: &mut LayoutContext,
+    regular_font: &Arc<krilla::text::Font>,
+    bold_font: &Arc<krilla::text::Font>,
+    font_size: f32,
+    x: f32,
+    y: f32,
+    _max_width: f32,
+) -> f32 {
+    let mut current_x = x;
+
+    for segment in segments {
+        let font = if segment.style.bold {
+            bold_font.as_ref().clone()
+        } else {
+            regular_font.as_ref().clone()
+        };
+
+        surface.draw_text(
+            Point::from_xy(current_x, y + font_size),
+            font,
+            font_size,
+            &segment.text,
+            false,
+            TextDirection::Auto,
+        );
+
+        current_x += estimate_text_width(&segment.text, font_size);
+    }
+
+    y + font_size * 1.5
+}
+
+/// Helper function to render header
+#[allow(clippy::too_many_arguments)]
+fn render_header_helper(
+    surface: &mut Surface,
+    hf_font: &Arc<krilla::text::Font>,
+    config: &Config,
+    page_number: usize,
+    total_pages: usize,
+    date_str: &str,
+    margin_left: f32,
+    margin_top: f32,
+    content_width: f32,
+    page_width: f32,
+    margin_right: f32,
+) -> Result<()> {
+    let hf_ctx = HeaderFooterContext {
+        page_number,
+        total_pages,
+        current_filename: "",
+        date: date_str,
+    };
+    header_footer::render_header(
+        surface,
+        hf_font.clone(),
+        &config.header,
+        &hf_ctx,
+        margin_left,
+        margin_top,
+        content_width,
+        page_width,
+        margin_right,
+    )
+}
+
+/// Helper function to render footer
+#[allow(clippy::too_many_arguments)]
+fn render_footer_helper(
+    surface: &mut Surface,
+    hf_font: &Arc<krilla::text::Font>,
+    config: &Config,
+    page_number: usize,
+    total_pages: usize,
+    date_str: &str,
+    margin_left: f32,
+    page_height: f32,
+    margin_bottom: f32,
+    content_width: f32,
+    page_width: f32,
+    margin_right: f32,
+) -> Result<()> {
+    let hf_ctx = HeaderFooterContext {
+        page_number,
+        total_pages,
+        current_filename: "",
+        date: date_str,
+    };
+    header_footer::render_footer(
+        surface,
+        hf_font.clone(),
+        &config.footer,
+        &hf_ctx,
+        margin_left,
+        page_height,
+        margin_bottom,
+        content_width,
+        page_width,
+        margin_right,
+    )
+}
+
+/// Add link annotations to a page
+fn add_link_annotations(page: &mut krilla::page::Page, pending_links: &mut Vec<MarkdownLink>) {
+    for link in pending_links.drain(..) {
+        if link.url.starts_with("http://") || link.url.starts_with("https://") {
+            let link_action = LinkAction::new(link.url);
+            let link_annotation =
+                LinkAnnotation::new(link.rect, Target::Action(Action::Link(link_action)));
+            page.add_annotation(Annotation::new_link(link_annotation, None));
+        }
+    }
+}
+
+/// Load an image from a file path
+fn load_image(path: &Path) -> Option<Image> {
+    let image_data = fs::read(path).ok()?;
+    let extension = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_lowercase())
+        .unwrap_or_default();
+
+    match extension.as_str() {
+        "png" => Image::from_png(image_data.into(), true).ok(),
+        "jpg" | "jpeg" => Image::from_jpeg(image_data.into(), true).ok(),
+        "gif" => Image::from_gif(image_data.into(), true).ok(),
+        "webp" => Image::from_webp(image_data.into(), true).ok(),
+        _ => None,
+    }
+}
+
+/// Estimate text width based on font size
+fn estimate_text_width(text: &str, font_size: f32) -> f32 {
+    text.len() as f32 * font_size * 0.5
+}

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -32,6 +32,7 @@ mod fonts;
 mod generator;
 mod header_footer;
 mod krilla_doc;
+mod markdown_renderer;
 pub mod themes;
 
 pub use generator::generate;


### PR DESCRIPTION
## Summary
- Adds markdown report feature that renders directly to PDF (no merging)
- Supports SVG images as vector graphics
- Includes standard markdown elements: headings, lists, code blocks, blockquotes, links

Closes #7

## Test plan
- [ ] Run `cargo run -- -c examples/markdown_report/config.yaml -f`
- [ ] Verify PDF contains rendered markdown with Papercut logo as vector graphic