### PR TITLE
Add custom font family configuration for source code

### DIFF
--- a/examples/full_config.yaml
+++ b/examples/full_config.yaml
@@ -80,6 +80,11 @@ page:
     left: "2.0cm"     # 2.0 cm (explicit)
     right: 2.0        # 2.0 cm
 
+  # Font family for source code (optional)
+  # If not specified, auto-detects from: Consolas, Monaco, Menlo, DejaVu Sans Mono, etc.
+  # Common options: "JetBrains Mono", "Fira Code", "Source Code Pro", "Consolas", "Monaco"
+  # font_family: "JetBrains Mono"
+
   # Font size for code content (in points)
   # Typical values: 8-12
   font_size: 10
@@ -126,7 +131,7 @@ cover_page:
   # Main title displayed prominently on the cover page
   title: "Source Code Documentation"
 
-  # Author(s) displayed below the title (supports single string or list)
+  # Author(s) displayed below the title (supports string or list)
   # Single author: authors: "John Doe"
   # Multiple authors (shown one per line):
   authors:

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,52 @@ use std::fmt;
 use std::path::PathBuf;
 use crate::error::{PapercutError, Result};
 
+/// Deserialize a field that can be either a string or a list of strings.
+/// If a list is provided, items are joined with double newlines.
+fn string_or_list<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct StringOrList;
+
+    impl<'de> Visitor<'de> for StringOrList {
+        type Value = String;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a string or a list of strings")
+        }
+
+        fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(value.to_string())
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+        where
+            A: de::SeqAccess<'de>,
+        {
+            let mut items = Vec::new();
+            while let Some(item) = seq.next_element::<String>()? {
+                items.push(item);
+            }
+            // Join with double newlines to create paragraph breaks
+            Ok(items.join("\n\n"))
+        }
+    }
+
+    deserializer.deserialize_any(StringOrList)
+}
+
+/// Wrapper for Option<String> that can deserialize from string or list
+fn option_string_or_list<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    string_or_list(deserializer)
+}
+
 /// A margin value that can be specified in cm or inches.
 /// Internally stored as points (1 inch = 72 points, 1 cm = 28.3465 points).
 #[derive(Debug, Clone, Copy)]
@@ -249,6 +295,9 @@ pub struct PageConfig {
     /// Margins in centimeters
     #[serde(default)]
     pub margins: MarginsConfig,
+    /// Font family for source code (optional, auto-detects if not specified)
+    #[serde(default)]
+    pub font_family: Option<String>,
     /// Font size for code content
     #[serde(default = "default_font_size")]
     pub font_size: u8,
@@ -277,6 +326,7 @@ impl Default for PageConfig {
         Self {
             size: default_page_size(),
             margins: MarginsConfig::default(),
+            font_family: None,
             font_size: default_font_size(),
             line_numbers: true,
             line_number_separator: true,
@@ -450,8 +500,8 @@ pub struct CoverPageConfig {
     /// Title to display on the cover page
     #[serde(default)]
     pub title: String,
-    /// Authors text for the cover page (supports multiple lines with double newlines)
-    #[serde(default)]
+    /// Authors text for the cover page (accepts a string or list of strings)
+    #[serde(default, deserialize_with = "option_string_or_list")]
     pub authors: String,
     /// Description text for the cover page
     #[serde(default)]

--- a/src/pdf/fonts.rs
+++ b/src/pdf/fonts.rs
@@ -59,9 +59,27 @@ impl FontManager {
     }
 
     /// Get or load a monospace font suitable for code display
-    pub fn get_monospace_font(&mut self) -> Result<Arc<Font>> {
+    /// If `preferred` is provided, tries that font first before falling back to defaults
+    pub fn get_monospace_font(&mut self, preferred: Option<&str>) -> Result<Arc<Font>> {
         if let Some(font) = &self.monospace_font {
             return Ok(Arc::clone(font));
+        }
+
+        // Try the preferred font first if specified
+        if let Some(preferred_family) = preferred {
+            if let Some(font) = self.try_load_font(preferred_family) {
+                let font_arc = Arc::new(font);
+                self.monospace_font = Some(Arc::clone(&font_arc));
+                return Ok(font_arc);
+            }
+            // Preferred font not found, warn and fall back
+            self.warning_manager.warnf(
+                WarningCategory::Fonts,
+                format!(
+                    "Preferred font '{}' not found, falling back to system defaults",
+                    preferred_family
+                )
+            );
         }
 
         // Try to find a good monospace font in order of preference
@@ -127,7 +145,7 @@ impl FontManager {
         }
 
         // Fall back to monospace if no serif font available
-        self.get_monospace_font()
+        self.get_monospace_font(None)
     }
 
     /// Get or load a font for headers/footers (reuses cover font)
@@ -285,7 +303,7 @@ mod tests {
     #[test]
     fn test_find_monospace_font() {
         let mut manager = FontManager::new(Arc::new(WarningManager::new(false)));
-        let result = manager.get_monospace_font();
+        let result = manager.get_monospace_font(None);
         assert!(result.is_ok(), "Should find at least one monospace font");
     }
 }

--- a/src/pdf/generator.rs
+++ b/src/pdf/generator.rs
@@ -335,7 +335,7 @@ fn generate_single_pdf(config: Config, verbose: bool, force: bool, warning_manag
     // Pre-calculate document layout (page indices and total pages)
     let layout = calculate_document_layout(&config, &ctx)?;
 
-    let font = ctx.font_manager.get_monospace_font()?;
+    let font = ctx.font_manager.get_monospace_font(config.page.font_family.as_deref())?;
     let hf_font = ctx.font_manager.get_header_footer_font()?;
 
     // Initialize header/footer state
@@ -1187,7 +1187,7 @@ fn generate_multiple_pdfs(config: Config, verbose: bool, force: bool, warning_ma
         let effective_metadata = config.effective_metadata();
         ctx.set_metadata(&effective_metadata);
 
-        let font = ctx.font_manager.get_monospace_font()?;
+        let font = ctx.font_manager.get_monospace_font(config.page.font_family.as_deref())?;
         let hf_font = ctx.font_manager.get_header_footer_font()?;
 
         // For multiple mode, calculate pages for this single file

--- a/src/pdf/krilla_doc.rs
+++ b/src/pdf/krilla_doc.rs
@@ -59,7 +59,7 @@ impl PdfContext {
         let mut font_manager = FontManager::new(warning_manager);
 
         // Pre-load the monospace font
-        font_manager.get_monospace_font()?;
+        font_manager.get_monospace_font(config.page.font_family.as_deref())?;
 
         // Calculate page dimensions and margins (all in points)
         let (page_width_pt, page_height_pt) = get_page_size_points(&config.page.size);

--- a/src/pdf/markdown_renderer.rs
+++ b/src/pdf/markdown_renderer.rs
@@ -116,7 +116,7 @@ pub fn render_markdown(
     // Get fonts for krilla drawing
     let font = font_manager.get_cover_font("Arial")?;
     let bold_font = font_manager.get_cover_bold_font("Arial")?;
-    let mono_font = font_manager.get_monospace_font()?;
+    let mono_font = font_manager.get_monospace_font(None)?;
     let hf_font = font_manager.get_header_footer_font()?;
 
     // Initialize parley for text layout


### PR DESCRIPTION
## Summary

- Add `font_family` option to `page` config section for specifying a preferred monospace font for source code rendering
- Support both string and list formats for `cover_page.authors` field
- Emit warning when preferred font not found, gracefully fall back to system defaults

## Configuration

```yaml
page:
  font_family: "JetBrains Mono"  # Optional - auto-detects if not specified
  font_size: 12
```

## Test plan

- [x] Test with custom font (e.g., Monaco, JetBrains Mono)
- [x] Test fallback when invalid font name is specified (warning emitted, uses default)
- [x] Test without `font_family` specified (existing behavior preserved)
- [x] Test `cover_page.authors` as both string and list formats
- [x] All existing tests pass