### PR TITLE
Update documentation for v1.1 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ To uninstall: Delete Papercut.app and run `sudo rm /usr/local/bin/papercut`
 #### Build from Source
 
 ```bash
-git clone https://github.com/yourusername/papercut.git
-cd papercut
+git clone https://github.com/chrislupp/Papercut.git
+cd Papercut
 cargo install --path .
 ```
 
@@ -53,12 +53,15 @@ papercut --config config.yaml
 ### Features
 
 - **Cover Pages**: Optional cover page with title, description, location, date, and table of contents
+- **Markdown Reports**: Include markdown documentation with images and formatting before source code
 - **Directory Scanning & Glob Patterns**: Use wildcards (`*.rs`, `src/**/*.py`) and scan entire directories
 - **File Filtering**: Include/exclude specific file types and patterns
 - **Single or Multiple PDFs**: Combine all files or create separate PDFs
-- **Syntax Highlighting**: Optional syntax highlighting with multiple themes
+- **Syntax Highlighting**: Built-in themes (VS Code, JetBrains) plus custom syntax support
+- **Custom Fonts**: Specify preferred monospace font for source code rendering
 - **Customizable Headers/Footers**: Add page numbers, dates, filenames, and custom text
-- **Flexible Formatting**: Configure page size, margins, fonts, and colors
+- **Line Wrapping**: Automatic wrapping of long lines with configurable indentation
+- **Flexible Formatting**: Configure page size, margins, fonts, line numbers, and borders
 - **PDF Metadata**: Set title, author, subject, and keywords
 - **Robust Error Handling**: Detailed error messages with actionable suggestions
 - **Configurable Warnings**: Control warning output by category
@@ -73,6 +76,7 @@ See the `examples/` directory:
 - `full_config.yaml` - All available options with comments
 - `release_config.yaml` - Public release template
 - `patterns_config.yaml` - Directory scanning and pattern matching examples
+- `markdown_report/` - Markdown report with embedded images
 
 ### Documentation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,9 @@ The configuration file is organized into the following sections:
 - `footer` - Footer configuration
 - `styling` - Visual styling options
 - `metadata` - PDF metadata
+- `warnings` - Warning configuration
 - `cover_page` - Cover page configuration
+- `markdown_report` - Markdown report configuration
 
 ## Output Configuration
 
@@ -140,17 +142,26 @@ Controls syntax highlighting for source code.
 ```yaml
 syntax_highlighting:
   enabled: true
-  theme: base16-ocean.dark
+  theme: vscode-light
+  custom_syntaxes:
+    - /path/to/syntaxes/  # Directory of .sublime-syntax files
+    - /path/to/Custom.sublime-syntax  # Individual syntax file
 ```
 
 ### Fields
 
-- **enabled** (optional, default: `false`): Enable syntax highlighting
+- **enabled** (optional, default: `true`): Enable syntax highlighting
   - Requires the `syntax-highlighting` feature to be enabled
 
-- **theme** (optional, default: `base16-ocean.dark`): Theme name
+- **theme** (optional, default: `vscode-light`): Theme name
   - Run `papercut --list-themes` to see available themes
-  - Popular themes: `InspiredGitHub`, `Solarized (dark)`, `Solarized (light)`
+  - **Built-in presets**: `vscode-light`, `vscode-dark`, `jetbrains-light`, `jetbrains-darcula`
+  - **Popular themes**: `InspiredGitHub`, `Solarized (dark)`, `Solarized (light)`, `base16-ocean.dark`
+
+- **custom_syntaxes** (optional): List of custom syntax definition paths
+  - Can be directories (scanned for all `.sublime-syntax` files) or individual files
+  - Useful for languages not included in the default set (e.g., CMake)
+  - Syntax files use the Sublime Text `.sublime-syntax` format
 
 ## Page Configuration
 
@@ -164,9 +175,14 @@ page:
     bottom: "1in"     # 1 inch (string with unit)
     left: "2.0cm"     # 2.0 cm (explicit unit)
     right: 2.0
+  font_family: "JetBrains Mono"  # Optional custom font
   font_size: 10
   line_numbers: true
+  line_number_separator: true
+  vertical_borders: true
   line_spacing: 1.2
+  wrap_long_lines: true
+  wrap_indent: 4
 ```
 
 ### Fields
@@ -187,15 +203,32 @@ page:
   - String with `cm` suffix: Centimeters (e.g., `"2.5cm"`)
   - String with `in` suffix: Inches (e.g., `"1in"`, `"0.75in"`)
 
+- **font_family** (optional): Preferred monospace font for source code
+  - If not specified, auto-detects from: Consolas, Monaco, Menlo, DejaVu Sans Mono, etc.
+  - Common options: `"JetBrains Mono"`, `"Fira Code"`, `"Source Code Pro"`, `"Consolas"`, `"Monaco"`
+  - If the specified font is not found, a warning is emitted and falls back to system defaults
+
 - **font_size** (optional, default: `10`): Font size for code content in points
   - Typical values: 8-12
 
 - **line_numbers** (optional, default: `true`): Show line numbers
 
+- **line_number_separator** (optional, default: `true`): Show vertical line between line numbers and code
+
+- **vertical_borders** (optional, default: `true`): Show vertical borders at left and right edges of content
+
 - **line_spacing** (optional, default: `1.2`): Line spacing multiplier
   - 1.0 = single spacing
   - 1.5 = 1.5× spacing
   - 2.0 = double spacing
+
+- **wrap_long_lines** (optional, default: `true`): Enable line wrapping for long lines
+  - When enabled, lines exceeding the page width wrap to the next line
+  - When disabled, long lines are truncated
+
+- **wrap_indent** (optional, default: `4`): Indentation for wrapped continuation lines
+  - Number of spaces to indent wrapped lines
+  - Helps visually distinguish continuation lines from new source lines
 
 ## Header/Footer Configuration
 
@@ -290,6 +323,30 @@ metadata:
 
 - **keywords** (optional): List of keywords for searchability
 
+## Warnings Configuration
+
+Controls warning output during PDF generation.
+
+```yaml
+warnings:
+  enabled: true
+  silence_categories:
+    - fonts        # Silence font-related warnings
+    - themes       # Silence theme-related warnings
+```
+
+### Fields
+
+- **enabled** (optional, default: `true`): Enable or disable all warnings
+  - When `false`, all warnings are suppressed
+  - Can also be overridden with `--quiet` CLI flag
+
+- **silence_categories** (optional): List of warning categories to silence
+  - `fonts`: Font file read failures and fallback behavior
+  - `themes`: Custom theme loading and parsing errors
+  - `highlighting`: Syntax highlighting failures (falls back to plain text)
+  - `filesystem`: Directory walking errors, permission denied, non-UTF-8 paths
+
 ## Cover Page Configuration
 
 Controls the optional cover page that appears before the printed code.
@@ -310,6 +367,12 @@ cover_page:
   title_font_size: 24
   text_font_size: 12
   font_family: "Arial"                  # Cover page font
+  # Optional: Override header/footer for cover page only
+  header:
+    enabled: false
+  footer:
+    enabled: true
+    center: "Cover Page Footer"
 ```
 
 ### Fields
@@ -358,6 +421,14 @@ cover_page:
   - Common options: "Arial", "Helvetica", "Times New Roman", "Georgia"
   - Falls back to Arial if the specified font is not available
   - The title and "Description" heading are rendered in bold
+
+- **header** (optional): Override header configuration for cover page only
+  - If not specified, uses the main `header` configuration
+  - Accepts the same fields as the main header configuration
+
+- **footer** (optional): Override footer configuration for cover page only
+  - If not specified, uses the main `footer` configuration
+  - Accepts the same fields as the main footer configuration
 
 ### Examples
 
@@ -412,6 +483,61 @@ cover_page:
   text_font_size: 14
   description: "Complete technical documentation"
   location: "https://internal.company.com/alpha"
+```
+
+## Markdown Report Configuration
+
+Include a markdown document before the source code listing. Useful for adding documentation, analysis, or reports.
+
+```yaml
+markdown_report:
+  enabled: true
+  path: docs/report.md
+```
+
+### Fields
+
+- **enabled** (optional, default: `false`): Enable the markdown report
+  - When `true`, the markdown file is rendered before source code content
+
+- **path** (required when enabled): Path to the markdown file
+  - Can be relative to the config file or absolute
+  - Supports standard markdown formatting
+  - Images are embedded (supports PNG, JPEG, SVG)
+  - Code blocks are syntax highlighted
+
+### Supported Markdown Features
+
+- **Headings**: `#`, `##`, `###`, etc.
+- **Text formatting**: Bold, italic, strikethrough
+- **Lists**: Ordered and unordered
+- **Code blocks**: Fenced code blocks with syntax highlighting
+- **Images**: Local images are embedded in the PDF
+- **Links**: Displayed as text (PDFs don't support clickable links in body)
+- **Block quotes**: Indented quote blocks
+- **Horizontal rules**: Page separators
+
+### Example
+
+```yaml
+markdown_report:
+  enabled: true
+  path: analysis/code_review.md
+```
+
+Where `code_review.md` might contain:
+
+```markdown
+# Code Review Summary
+
+## Overview
+This document provides an analysis of the authentication module.
+
+## Key Findings
+- Input validation is comprehensive
+- Session handling follows best practices
+
+![Architecture Diagram](diagrams/auth_flow.svg)
 ```
 
 ## Minimal Configuration Example

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,6 +5,7 @@ This document provides real-world configuration examples for common use cases.
 ## Table of Contents
 
 - [Code Review Documentation](#code-review-documentation)
+- [Technical Report with Markdown](#technical-report-with-markdown)
 - [Public Release Package](#public-release-package)
 - [Internal Audit Trail](#internal-audit-trail)
 - [API Documentation](#api-documentation)
@@ -70,6 +71,103 @@ metadata:
 **Usage:**
 ```bash
 papercut -c config.yaml -v
+```
+
+---
+
+## Technical Report with Markdown
+
+Include a technical analysis or documentation before source code listing.
+
+**Use Case**: Code audits with findings, architecture documentation, technical reports
+
+**report_config.yaml:**
+```yaml
+output:
+  mode: single
+  directory: ./reports
+  filename: security_analysis_2024.pdf
+
+# Include markdown report before source code
+markdown_report:
+  enabled: true
+  path: docs/security_analysis.md
+
+files:
+  - path: src/auth/
+    include_types: ["rs"]
+    title: "Authentication Module"
+  - path: src/crypto/
+    include_types: ["rs"]
+    title: "Cryptography Module"
+
+syntax_highlighting:
+  enabled: true
+  theme: vscode-light
+
+page:
+  size: Letter
+  font_family: "JetBrains Mono"
+  font_size: 9
+  line_numbers: true
+  wrap_long_lines: true
+  wrap_indent: 4
+
+cover_page:
+  enabled: true
+  title: "Security Code Analysis"
+  authors:
+    - "Security Team"
+    - "Architecture Team"
+  description: |
+    Comprehensive security analysis of authentication and
+    cryptography modules with code review findings.
+  include_toc: true
+
+header:
+  enabled: true
+  left: "CONFIDENTIAL"
+  right: "Page {page}/{total}"
+
+footer:
+  enabled: true
+  left: "{date}"
+  center: "{filename}"
+  right: "Security Review"
+
+metadata:
+  title: "Security Code Analysis 2024"
+  author: "Security Team"
+  keywords: ["security", "audit", "code review"]
+```
+
+**docs/security_analysis.md:**
+```markdown
+# Security Analysis Report
+
+## Executive Summary
+
+This report documents the security review of the authentication
+and cryptography modules.
+
+## Findings
+
+### High Priority
+
+1. **Input Validation** - All user inputs are properly sanitized
+2. **Session Management** - Tokens expire appropriately
+
+### Recommendations
+
+- Consider adding rate limiting to login endpoints
+- Implement additional logging for failed auth attempts
+
+![Security Architecture](diagrams/auth_flow.svg)
+```
+
+**Usage:**
+```bash
+papercut -c report_config.yaml -v
 ```
 
 ---

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -66,22 +66,45 @@ Common values:
 
 ## Typography
 
-### Font Families
+### Custom Font Family
 
-Papercut supports three monospace font families for code:
+You can specify a preferred monospace font for source code rendering:
+
+```yaml
+page:
+  font_family: "JetBrains Mono"  # Optional - auto-detects if not specified
+```
+
+If not specified, Papercut auto-detects from available system fonts in this order:
+Consolas, Monaco, Menlo, DejaVu Sans Mono, Liberation Mono, Courier New, Courier.
+
+**Popular programming fonts:**
+
+| Font              | Style           | Notes                          |
+|-------------------|-----------------|--------------------------------|
+| JetBrains Mono    | Modern          | Designed for code, ligatures   |
+| Fira Code         | Modern          | Popular, ligature support      |
+| Source Code Pro   | Clean           | Adobe's coding font            |
+| Consolas          | Classic         | Windows default, very readable |
+| Monaco            | Classic         | macOS classic                  |
+| DejaVu Sans Mono  | Professional    | Good Unicode support           |
+
+If the specified font is not found, a warning is displayed and the system falls back to available fonts.
+
+### Legacy Styling Font Family
+
+The `styling.font_family` option provides preset choices (deprecated in favor of `page.font_family`):
 
 ```yaml
 styling:
   font_family: monospace  # or courier, dejavu
 ```
 
-Font characteristics:
-
-| Font      | Style       | Best For                    |
-|-----------|-------------|------------------------------|
-| monospace | Clean, modern | General purpose, modern look |
-| courier   | Classic     | Traditional code listings    |
-| dejavu    | Professional | Professional documentation   |
+| Preset    | Description                          |
+|-----------|--------------------------------------|
+| monospace | Generic monospace (system default)   |
+| courier   | Courier New                          |
+| dejavu    | DejaVu Sans Mono                     |
 
 ### Font Sizes
 
@@ -119,6 +142,44 @@ Line numbers appear on the left side of code with the format:
    1 | fn main() {
    2 |     println!("Hello, world!");
    3 | }
+```
+
+### Line Number Separator
+
+Show or hide the vertical line between line numbers and code:
+
+```yaml
+page:
+  line_number_separator: true  # or false
+```
+
+### Vertical Borders
+
+Show or hide vertical borders at the left and right edges of the code area:
+
+```yaml
+page:
+  vertical_borders: true  # or false
+```
+
+### Line Wrapping
+
+Control how long lines are handled:
+
+```yaml
+page:
+  wrap_long_lines: true   # Enable line wrapping (default)
+  wrap_indent: 4          # Indentation for wrapped lines
+```
+
+- **wrap_long_lines**: When `true`, lines exceeding page width wrap to the next line. When `false`, lines are truncated.
+- **wrap_indent**: Number of spaces to indent continuation lines (helps distinguish them from new source lines)
+
+Example with wrapping enabled and `wrap_indent: 4`:
+```
+   1 | let very_long_variable_name = some_function_call(argument1,
+       argument2, argument3);
+   2 | let short = 42;
 ```
 
 ## Colors
@@ -187,7 +248,7 @@ styling:
 ```yaml
 syntax_highlighting:
   enabled: true
-  theme: base16-ocean.dark
+  theme: vscode-light
 ```
 
 ### Available Themes
@@ -198,12 +259,30 @@ To see all available themes:
 papercut --list-themes
 ```
 
+### Built-in Presets
+
+Papercut includes optimized presets for popular editors:
+
+| Preset             | Style | Description                        |
+|--------------------|-------|------------------------------------|
+| `vscode-light`     | Light | VS Code light theme (default)      |
+| `vscode-dark`      | Dark  | VS Code dark theme                 |
+| `jetbrains-light`  | Light | IntelliJ/JetBrains light theme     |
+| `jetbrains-darcula`| Dark  | IntelliJ Darcula theme             |
+
+```yaml
+syntax_highlighting:
+  enabled: true
+  theme: vscode-dark
+```
+
 ### Popular Themes
 
 #### Light Themes
 
 Good for printing and professional documents:
 
+- **vscode-light**: VS Code default light (recommended)
 - **InspiredGitHub**: Clean, GitHub-style highlighting
 - **Solarized (light)**: Carefully designed color palette
 - **base16-ocean.light**: Soft, ocean-inspired colors
@@ -211,13 +290,15 @@ Good for printing and professional documents:
 ```yaml
 syntax_highlighting:
   enabled: true
-  theme: InspiredGitHub
+  theme: vscode-light
 ```
 
 #### Dark Themes
 
 Good for screen reading and presentations:
 
+- **vscode-dark**: VS Code dark theme
+- **jetbrains-darcula**: IntelliJ Darcula (popular)
 - **base16-ocean.dark**: Popular dark theme with blue tones
 - **Solarized (dark)**: Professional dark theme
 - **Monokai**: High contrast, vibrant colors
@@ -225,7 +306,7 @@ Good for screen reading and presentations:
 ```yaml
 syntax_highlighting:
   enabled: true
-  theme: base16-ocean.dark
+  theme: jetbrains-darcula
 ```
 
 ### Choosing a Theme

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,8 +8,8 @@ This guide covers how to use Papercut from the command line.
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/papercut.git
-cd papercut
+git clone https://github.com/chrislupp/Papercut.git
+cd Papercut
 
 # Build and install
 cargo install --path .
@@ -82,6 +82,32 @@ Rendering PDF to: ./output/combined.pdf
 PDF generation completed successfully!
 ```
 
+### `--force` / `-f`
+
+Force overwrite existing files without prompting.
+
+```bash
+papercut --config config.yaml --force
+papercut -c config.yaml -f
+```
+
+**Required**: No
+
+Use this flag in non-interactive environments (CI/CD pipelines, scripts) where prompts cannot be answered.
+
+### `--quiet` / `-q`
+
+Suppress all warning messages.
+
+```bash
+papercut --config config.yaml --quiet
+papercut -c config.yaml -q
+```
+
+**Required**: No
+
+Overrides the `warnings.enabled` setting in the configuration file. Useful for clean output in automated pipelines.
+
 ### `--list-themes`
 
 List all available syntax highlighting themes (requires `syntax-highlighting` feature).
@@ -95,11 +121,19 @@ Example output:
 ```
 Available syntax highlighting themes:
 
+Built-in presets:
+  - vscode-light (default)
+  - vscode-dark
+  - jetbrains-light
+  - jetbrains-darcula
+
+Additional themes:
   - InspiredGitHub
   - Solarized (dark)
   - Solarized (light)
   - base16-ocean.dark
   - base16-ocean.light
+  ...
 
 Use these theme names in your configuration file.
 ```


### PR DESCRIPTION
## Summary

Comprehensive documentation update to reflect all features added since v1.0.

- Document new `page.font_family` option for custom monospace fonts
- Document line wrapping options (`wrap_long_lines`, `wrap_indent`)
- Document visual options (`line_number_separator`, `vertical_borders`)
- Document `syntax_highlighting.custom_syntaxes` for custom syntax definitions
- Add `markdown_report` configuration section
- Add `warnings` configuration section
- Document cover page `header`/`footer` overrides
- Document built-in theme presets (vscode-light, vscode-dark, jetbrains-light, jetbrains-darcula)
- Document `--force` and `--quiet` CLI flags
- Fix incorrect defaults in docs (theme default is `vscode-light`, syntax highlighting enabled by default)
- Fix repository URL to `github.com/chrislupp/Papercut`
- Add "Technical Report with Markdown" example

## Files Changed

| File | Changes |
|------|---------|
| `README.md` | Fixed repo URL, updated features list |
| `docs/configuration.md` | Added 7 new sections/options |
| `docs/usage.md` | Added --force/--quiet flags |
| `docs/styling.md` | Added fonts, wrapping, borders, presets |
| `docs/examples.md` | Added markdown report example |

## Test plan

- [x] All code compiles successfully
- [x] All tests pass
- [ ] Review documentation for accuracy and completeness